### PR TITLE
feat: add nullable kind column for typed document scoping (#16)

### DIFF
--- a/migrations/002_add_kind_column.sql
+++ b/migrations/002_add_kind_column.sql
@@ -1,0 +1,9 @@
+-- 002_add_kind_column.sql
+-- Add nullable `kind` to docs for typed-document scoping (issue #16).
+-- Composite index supports owner-scoped, kind-filtered, recent-first listings
+-- with the same (created_at, id) cursor shape used by the unfiltered listing.
+
+ALTER TABLE docs ADD COLUMN kind text;
+
+CREATE INDEX idx_docs_owner_kind_created
+  ON docs (owner_id, kind, created_at DESC, id DESC);

--- a/src/app/api/list/route.ts
+++ b/src/app/api/list/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { listDocs } from "@/lib/db";
+import { parseKind } from "@/lib/kind";
 
 function jsonError(status: number, message: string) {
   return new Response(JSON.stringify({ error: message }), {
@@ -27,11 +28,18 @@ export async function GET(req: NextRequest) {
   const cursor = searchParams.get("cursor") ?? undefined;
   const search = searchParams.get("search") ?? undefined;
 
+  const kindParam = searchParams.get("kind");
+  const kindResult = parseKind(kindParam);
+  if (!kindResult.ok) {
+    return jsonError(400, kindResult.error);
+  }
+
   const result = await listDocs({
     ownerId: auth.ownerId,
     limit,
     cursor,
     search,
+    kind: kindResult.value ?? undefined,
   });
 
   return new Response(
@@ -40,6 +48,7 @@ export async function GET(req: NextRequest) {
         id: d.id,
         slug: d.slug,
         title: d.title,
+        kind: d.kind,
         createdAt: d.createdAt,
       })),
       nextCursor: result.nextCursor,

--- a/src/app/api/raw/[slug]/route.ts
+++ b/src/app/api/raw/[slug]/route.ts
@@ -25,6 +25,7 @@ export async function GET(
       JSON.stringify({
         slug: doc.slug,
         title: doc.title,
+        kind: doc.kind,
         content: doc.content,
         createdAt: doc.createdAt,
         updatedAt: doc.updatedAt,

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -4,11 +4,12 @@ import { generateSlug } from "@/lib/slug";
 import { resolveTitle } from "@/lib/title";
 import { stripMarkdown } from "@/lib/strip-md";
 import { insertDoc } from "@/lib/db";
+import { parseKind } from "@/lib/kind";
 
 const MAX_BYTES = 1024 * 1024;
 const MAX_SLUG_RETRIES = 5;
 
-type UploadInput = { content: string; title?: string };
+type UploadInput = { content: string; title?: string; kind?: unknown };
 
 function jsonError(status: number, message: string) {
   return new Response(JSON.stringify({ error: message }), {
@@ -51,7 +52,12 @@ async function parseBody(req: NextRequest): Promise<UploadInput | { error: { sta
     return { error: { status: 413, message: "Content exceeds 1MB limit" } };
   }
   const headerTitle = req.headers.get("x-title");
-  return { content: text, title: headerTitle ?? undefined };
+  const headerKind = req.headers.get("x-kind");
+  return {
+    content: text,
+    title: headerTitle ?? undefined,
+    kind: headerKind ?? undefined,
+  };
 }
 
 function buildViewUrl(req: NextRequest, slug: string): string {
@@ -84,6 +90,11 @@ export async function POST(req: NextRequest) {
     return jsonError(400, "Content is empty");
   }
 
+  const kindResult = parseKind(parsed.kind);
+  if (!kindResult.ok) {
+    return jsonError(400, kindResult.error);
+  }
+
   const title = resolveTitle(content, parsed.title);
   const searchText = stripMarkdown(content);
 
@@ -96,6 +107,7 @@ export async function POST(req: NextRequest) {
         ownerId: auth.ownerId,
         title,
         content,
+        kind: kindResult.value,
         searchText,
       });
       const viewUrl = buildViewUrl(req, doc.slug);
@@ -111,6 +123,7 @@ export async function POST(req: NextRequest) {
           id: doc.id,
           slug: doc.slug,
           title: doc.title,
+          kind: doc.kind,
           viewUrl,
           createdAt: doc.createdAt,
         }),

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -8,12 +8,16 @@ export type Doc = {
   ownerId: string;
   title: string;
   content: string;
+  kind: string | null;
   searchText: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
 
-export type DocSummary = Pick<Doc, "id" | "slug" | "title" | "createdAt" | "updatedAt">;
+export type DocSummary = Pick<
+  Doc,
+  "id" | "slug" | "title" | "kind" | "createdAt" | "updatedAt"
+>;
 
 type DocRow = {
   id: string;
@@ -21,6 +25,7 @@ type DocRow = {
   owner_id: string;
   title: string | null;
   content: string;
+  kind: string | null;
   search_text: string | null;
   created_at: Date;
   updated_at: Date;
@@ -30,6 +35,7 @@ type DocSummaryRow = {
   id: string;
   slug: string;
   title: string | null;
+  kind: string | null;
   created_at: Date;
   updated_at: Date;
 };
@@ -41,6 +47,7 @@ function rowToDoc(row: DocRow): Doc {
     ownerId: row.owner_id,
     title: row.title ?? "Untitled",
     content: row.content,
+    kind: row.kind,
     searchText: row.search_text,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -52,6 +59,7 @@ function rowToSummary(row: DocSummaryRow): DocSummary {
     id: row.id,
     slug: row.slug,
     title: row.title ?? "Untitled",
+    kind: row.kind,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -70,12 +78,13 @@ export async function insertDoc(input: {
   ownerId: string;
   title: string;
   content: string;
+  kind: string | null;
   searchText: string;
 }): Promise<Doc> {
   const result = await sql<DocRow>`
-    INSERT INTO docs (slug, owner_id, title, content, search_text)
-    VALUES (${input.slug}, ${input.ownerId}, ${input.title}, ${input.content}, ${input.searchText})
-    RETURNING id, slug, owner_id, title, content, search_text, created_at, updated_at
+    INSERT INTO docs (slug, owner_id, title, content, kind, search_text)
+    VALUES (${input.slug}, ${input.ownerId}, ${input.title}, ${input.content}, ${input.kind}, ${input.searchText})
+    RETURNING id, slug, owner_id, title, content, kind, search_text, created_at, updated_at
   `;
   const row = result.rows[0];
   if (!row) throw new Error("INSERT returned no rows");
@@ -89,7 +98,7 @@ export async function deleteDocBySlug(slug: string): Promise<boolean> {
 
 export async function getDocBySlug(slug: string): Promise<Doc | null> {
   const result = await sql<DocRow>`
-    SELECT id, slug, owner_id, title, content, search_text, created_at, updated_at
+    SELECT id, slug, owner_id, title, content, kind, search_text, created_at, updated_at
     FROM docs
     WHERE slug = ${slug}
     LIMIT 1
@@ -103,6 +112,7 @@ export type ListDocsArgs = {
   search?: string;
   cursor?: string;
   limit?: number;
+  kind?: string;
 };
 
 export type ListDocsResult = {
@@ -147,6 +157,7 @@ function decodeCursor(cursor: string): CursorPayload | null {
 export async function listDocs(args: ListDocsArgs): Promise<ListDocsResult> {
   const limit = Math.max(1, Math.min(100, args.limit ?? 20));
   const search = args.search?.trim();
+  const kind = args.kind;
 
   // Search branch: rank by FTS relevance. Cursor pagination not supported with
   // search in v1 — caller should rely on search precision and the limit.
@@ -155,37 +166,39 @@ export async function listDocs(args: ListDocsArgs): Promise<ListDocsResult> {
     if (!tsQuery) {
       return { docs: [], nextCursor: null };
     }
-    const result = await sql<DocSummaryRow>`
-      SELECT id, slug, title, created_at, updated_at
-      FROM docs
-      WHERE owner_id = ${args.ownerId}
-        AND search_vector @@ to_tsquery('english', ${tsQuery})
-      ORDER BY ts_rank(search_vector, to_tsquery('english', ${tsQuery})) DESC,
-               created_at DESC,
-               id DESC
-      LIMIT ${limit}
-    `;
+    const result = kind
+      ? await sql<DocSummaryRow>`
+          SELECT id, slug, title, kind, created_at, updated_at
+          FROM docs
+          WHERE owner_id = ${args.ownerId}
+            AND kind = ${kind}
+            AND search_vector @@ to_tsquery('english', ${tsQuery})
+          ORDER BY ts_rank(search_vector, to_tsquery('english', ${tsQuery})) DESC,
+                   created_at DESC,
+                   id DESC
+          LIMIT ${limit}
+        `
+      : await sql<DocSummaryRow>`
+          SELECT id, slug, title, kind, created_at, updated_at
+          FROM docs
+          WHERE owner_id = ${args.ownerId}
+            AND search_vector @@ to_tsquery('english', ${tsQuery})
+          ORDER BY ts_rank(search_vector, to_tsquery('english', ${tsQuery})) DESC,
+                   created_at DESC,
+                   id DESC
+          LIMIT ${limit}
+        `;
     return { docs: result.rows.map(rowToSummary), nextCursor: null };
   }
 
   // Recent-first listing with cursor pagination.
   const cursor = args.cursor ? decodeCursor(args.cursor) : null;
-  const result = cursor
-    ? await sql<DocSummaryRow>`
-        SELECT id, slug, title, created_at, updated_at
-        FROM docs
-        WHERE owner_id = ${args.ownerId}
-          AND (created_at, id) < (${cursor.createdAt.toISOString()}, ${cursor.id})
-        ORDER BY created_at DESC, id DESC
-        LIMIT ${limit + 1}
-      `
-    : await sql<DocSummaryRow>`
-        SELECT id, slug, title, created_at, updated_at
-        FROM docs
-        WHERE owner_id = ${args.ownerId}
-        ORDER BY created_at DESC, id DESC
-        LIMIT ${limit + 1}
-      `;
+  const result = await runListQuery({
+    ownerId: args.ownerId,
+    kind: kind ?? null,
+    cursor,
+    limit,
+  });
 
   const rows = result.rows;
   const hasMore = rows.length > limit;
@@ -193,4 +206,53 @@ export async function listDocs(args: ListDocsArgs): Promise<ListDocsResult> {
   const last = page[page.length - 1];
   const nextCursor = hasMore && last ? encodeCursor(last) : null;
   return { docs: page.map(rowToSummary), nextCursor };
+}
+
+async function runListQuery(args: {
+  ownerId: string;
+  kind: string | null;
+  cursor: CursorPayload | null;
+  limit: number;
+}) {
+  const { ownerId, kind, cursor, limit } = args;
+  const fetchLimit = limit + 1;
+
+  if (kind && cursor) {
+    return sql<DocSummaryRow>`
+      SELECT id, slug, title, kind, created_at, updated_at
+      FROM docs
+      WHERE owner_id = ${ownerId}
+        AND kind = ${kind}
+        AND (created_at, id) < (${cursor.createdAt.toISOString()}, ${cursor.id})
+      ORDER BY created_at DESC, id DESC
+      LIMIT ${fetchLimit}
+    `;
+  }
+  if (kind) {
+    return sql<DocSummaryRow>`
+      SELECT id, slug, title, kind, created_at, updated_at
+      FROM docs
+      WHERE owner_id = ${ownerId}
+        AND kind = ${kind}
+      ORDER BY created_at DESC, id DESC
+      LIMIT ${fetchLimit}
+    `;
+  }
+  if (cursor) {
+    return sql<DocSummaryRow>`
+      SELECT id, slug, title, kind, created_at, updated_at
+      FROM docs
+      WHERE owner_id = ${ownerId}
+        AND (created_at, id) < (${cursor.createdAt.toISOString()}, ${cursor.id})
+      ORDER BY created_at DESC, id DESC
+      LIMIT ${fetchLimit}
+    `;
+  }
+  return sql<DocSummaryRow>`
+    SELECT id, slug, title, kind, created_at, updated_at
+    FROM docs
+    WHERE owner_id = ${ownerId}
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${fetchLimit}
+  `;
 }

--- a/src/lib/kind.ts
+++ b/src/lib/kind.ts
@@ -1,0 +1,23 @@
+export const KIND_MAX_LENGTH = 64;
+
+export type ParsedKind =
+  | { ok: true; value: string | null }
+  | { ok: false; error: string };
+
+/**
+ * Normalize a `kind` value from API input. Trims, lowercases, treats
+ * empty-after-trim as null. Returns an error past KIND_MAX_LENGTH so callers
+ * surface 400 rather than silently truncating an identifier.
+ */
+export function parseKind(raw: unknown): ParsedKind {
+  if (raw === undefined || raw === null) return { ok: true, value: null };
+  if (typeof raw !== "string") {
+    return { ok: false, error: "kind must be a string" };
+  }
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed.length === 0) return { ok: true, value: null };
+  if (trimmed.length > KIND_MAX_LENGTH) {
+    return { ok: false, error: `kind exceeds ${KIND_MAX_LENGTH} characters` };
+  }
+  return { ok: true, value: trimmed };
+}


### PR DESCRIPTION
Closes #16.

## Summary
- New `kind text` (nullable) on `docs` plus composite `(owner_id, kind, created_at DESC, id DESC)` index for fast owner+kind+recent listings (matches the existing cursor's `(created_at, id)` order so pagination stays index-only).
- `POST /api/upload` accepts `kind` in JSON body or `X-Kind` header. Server normalizes (trim → lowercase), 64-char cap, empty-after-trim → null. Header path is fine for `kind` since it's ASCII identifier-shaped (titles still need JSON for UTF-8).
- `GET /api/list` accepts `?kind=<value>` exact match, owner-scoped. Composes with `?search=` and `?cursor=`. Without `?kind`, behavior unchanged.
- `GET /api/raw/<slug>` JSON response now includes `kind`. Markdown response unchanged.
- `kind` surfaced in `Doc`/`DocSummary` types and the upload/list response shapes.
- `~/.claude/skills/md-upload/SKILL.md` (operator-global, not in this repo) updated with the new field, header, and list filter.

## Acceptance criteria
- [x] Migration adds `kind text` (nullable) to `docs`
- [x] Composite index `(owner_id, kind, created_at DESC)` for fast scoped listings
- [x] `POST /api/upload` accepts `kind` in JSON body or `X-Kind` header
- [ ] `PATCH /api/docs/[slug]` (issue #7) accepts `kind` updates and clearing — **deferred to #7 per the local sequencing note (this PR is #16, #7 lands the PATCH and bundles `kind` write support)**
- [x] `GET /api/list?kind=<value>` filters by exact match
- [x] `GET /api/list` without `kind` returns all docs for the owner (current behavior)
- [x] `GET /api/raw/<slug>` JSON response includes `kind`
- [x] Existing docs default to NULL kind; no data migration required
- [x] md-upload skill updated with the new field

## Validation
Migration applied to local (which is the shared Neon DB until #8). Smoke tests against local dev:
- JSON upload with `kind` → 201, response contains kind.
- `X-Kind: TEST-KIND  ` header → stored as `test-kind` (trim+lowercase round-trip).
- `GET /api/list?kind=test-kind` → only the two test docs.
- `GET /api/raw/<slug>` (JSON) → includes `kind`.
- `kind` of 65 chars on upload and list → 400 `kind exceeds 64 characters`.
- Test docs deleted afterward.

`pnpm exec tsc --noEmit` and `pnpm lint` both clean.