### PR TITLE
feat: PATCH /api/docs/[slug] + edit UI (#7)

### DIFF
--- a/docs/test-scenarios.md
+++ b/docs/test-scenarios.md
@@ -1,0 +1,97 @@
+# Test scenarios
+
+Reference for what behavior to cover when automated tests come online. Each scenario was verified manually via curl against a local dev server during the PR that introduced it; capture them here so we don't regress on them silently.
+
+Until there's a test runner, the curl recipes below are runnable as-is against `http://localhost:3000` with `MD_API_KEY` and `MD_API_OWNER_ID` set. The local DB is the shared Neon DB until #8 separates environments — be mindful of test data and clean up after yourself.
+
+For ownership scenarios that need a doc owned by a *different* user, insert directly via `@vercel/postgres` from a tsx script (one-off, not committed). Example shape:
+
+```ts
+import { config } from "dotenv";
+import { sql } from "@vercel/postgres";
+config({ path: ".env.local" });
+await sql`INSERT INTO docs (slug, owner_id, title, content) VALUES (${slug}, ${otherOwnerId}, 'spoof', '# spoof')`;
+```
+
+Cleanup that row afterward — non-owner DELETE from the API will (correctly) return 404 without touching it.
+
+---
+
+## Upload (`POST /api/upload`)
+
+- 201 with bearer auth and `Content-Type: text/markdown` body
+- 201 with bearer auth and JSON `{content, title?, kind?}` body
+- 400 on empty/whitespace-only content
+- 400 on non-string `kind`
+- 400 on `kind` over 64 chars
+- 413 on body over 1 MB
+- 401 on missing/invalid bearer
+- Title resolves: explicit override → first H1 → `"Untitled"`
+- `X-Title` header honors ASCII titles; UTF-8 (em-dash, accents, emoji) round-trips correctly only via JSON body
+- `X-Kind` header normalizes (trim + lowercase) just like JSON body
+- Bearer-uploaded docs land under `MD_API_OWNER_ID`; session-uploaded docs land under `user.id`
+
+## Edit (`PATCH /api/docs/[slug]`)
+
+- 200 + updated doc shape on owner PATCH of `content`
+- 200 on PATCH of `title` (explicit override sticks)
+- 200 on PATCH of `title: null` (re-derives from current H1)
+- 200 on PATCH of `content` + `title: null` (re-derives from new H1)
+- 200 on PATCH of `kind` (set or clear)
+- Title is preserved when only `content` is patched (PATCH only changes what you send)
+- 400 on empty body / no field provided
+- 400 on empty/whitespace `content`
+- 400 on non-string `content`
+- 401 on missing/invalid bearer
+- 404 on unknown slug
+- **404 on owner mismatch** (don't leak existence to non-owners; spoof doc remains untouched in DB)
+- 413 on body over 1 MB
+- `slug` field in body is silently ignored (slug stays immutable)
+- After PATCH: `search_vector` rebuilds — search hits the new term, no longer hits old terms
+- After PATCH: `revalidatePath("/")` and `revalidatePath("/v/<slug>")` invalidate caches; next view reflects new content + OG metadata
+
+## Delete (`DELETE /api/docs/[slug]`)
+
+- 204 on owner DELETE
+- 401 on missing/invalid bearer
+- 404 on unknown slug
+- **404 on owner mismatch** (spoof doc remains in DB after the bogus DELETE)
+
+## List (`GET /api/list`)
+
+- 200 with bearer auth, returns `{docs, nextCursor}` owner-scoped to the authenticated user
+- `?limit=` clamps to [1, 100], default 20
+- `?cursor=` (base64 of `created_at|id`) paginates older-first
+- `?search=` runs against `search_vector` (FTS), no cursor pagination on search
+- `?kind=` exact match, owner-scoped, composes with `?search=` and `?cursor=`
+- 400 on `kind` over 64 chars
+- Pre-existing docs with NULL `kind` appear in unfiltered list, absent from `?kind=<value>`
+
+## Raw read (`GET /api/raw/[slug]`)
+
+- Public (no auth) regardless of doc owner
+- Default response: `Content-Type: text/markdown; charset=utf-8`, body is raw markdown
+- `Accept: application/json` returns `{slug, title, kind, content, createdAt, updatedAt}`
+- 404 on unknown slug
+
+## View page (`GET /v/[slug]`)
+
+- Public (no auth) regardless of doc owner
+- 200 with rendered HTML, OG metadata, `noindex,nofollow`
+- After PATCH on the underlying doc: page reflects updated title/body without manual refresh (server-side `revalidatePath`)
+
+## Edit page (`GET /edit/[slug]`)
+
+- Requires session auth (proxy matcher includes `/edit/:slug*`)
+- 307 redirect to `/auth` for unauthenticated requests
+- Redirect to `/` for authenticated users not on the email allow list
+- **`notFound()` (404) when the authenticated user doesn't own the doc** (don't leak existence)
+- Renders form prefilled with title, kind, body
+- Save PATCHes only the fields that changed
+- Save → `router.push("/v/<slug>")` (silent on success; toasts only on error)
+
+## Cross-cutting
+
+- Bearer and session auth paths both use `requireAuth` and produce the same `auth.ownerId`
+- Bearer flow: `MD_API_KEY` and `MD_API_OWNER_ID` are trimmed at read-time (defense against trailing newlines from `echo "..." | vercel env add`)
+- Public endpoints (`/v/<slug>`, `/api/raw/<slug>`) intentionally remain unscoped — shareable URLs are the point

--- a/src/app/api/docs/[slug]/route.ts
+++ b/src/app/api/docs/[slug]/route.ts
@@ -1,6 +1,17 @@
 import { NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
 import { requireAuth } from "@/lib/auth";
-import { deleteDocBySlug } from "@/lib/db";
+import {
+  deleteDocBySlug,
+  getDocBySlug,
+  updateDocBySlug,
+  type UpdateDocFields,
+} from "@/lib/db";
+import { resolveTitle } from "@/lib/title";
+import { stripMarkdown } from "@/lib/strip-md";
+import { parseKind } from "@/lib/kind";
+
+const MAX_BYTES = 1024 * 1024;
 
 function jsonError(status: number, message: string) {
   return new Response(JSON.stringify({ error: message }), {
@@ -23,5 +34,127 @@ export async function DELETE(
   if (!deleted) {
     return jsonError(404, "Document not found");
   }
+  revalidatePath("/");
+  revalidatePath(`/v/${slug}`);
   return new Response(null, { status: 204 });
+}
+
+type PatchInput = {
+  content?: unknown;
+  title?: unknown;
+  kind?: unknown;
+};
+
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ slug: string }> },
+) {
+  const auth = await requireAuth(req);
+  if (!auth.authenticated) {
+    return jsonError(auth.status, auth.reason);
+  }
+
+  const { slug } = await context.params;
+
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && parseInt(contentLength, 10) > MAX_BYTES) {
+    return jsonError(413, "Content exceeds 1MB limit");
+  }
+
+  let body: PatchInput;
+  try {
+    body = (await req.json()) as PatchInput;
+  } catch {
+    return jsonError(400, "Invalid JSON body");
+  }
+  if (typeof body !== "object" || body === null) {
+    return jsonError(400, "JSON body required");
+  }
+
+  const hasContent = body.content !== undefined;
+  const hasTitle = body.title !== undefined;
+  const hasKind = body.kind !== undefined;
+  if (!hasContent && !hasTitle && !hasKind) {
+    return jsonError(400, "At least one of content, title, or kind is required");
+  }
+
+  let nextContent: string | undefined;
+  if (hasContent) {
+    if (typeof body.content !== "string") {
+      return jsonError(400, "content must be a string");
+    }
+    if (Buffer.byteLength(body.content, "utf8") > MAX_BYTES) {
+      return jsonError(413, "Content exceeds 1MB limit");
+    }
+    if (!body.content.trim()) {
+      return jsonError(400, "Content is empty");
+    }
+    nextContent = body.content;
+  }
+
+  let titleOverride: string | null | undefined;
+  if (hasTitle) {
+    if (body.title !== null && typeof body.title !== "string") {
+      return jsonError(400, "title must be a string or null");
+    }
+    titleOverride = body.title as string | null;
+  }
+
+  let nextKind: string | null | undefined;
+  if (hasKind) {
+    const parsed = parseKind(body.kind);
+    if (!parsed.ok) {
+      return jsonError(400, parsed.error);
+    }
+    nextKind = parsed.value;
+  }
+
+  const existing = await getDocBySlug(slug);
+  if (!existing) {
+    return jsonError(404, "Document not found");
+  }
+
+  const fields: UpdateDocFields = {};
+
+  // Title resolution mirrors upload semantics: explicit override → first H1 → "Untitled".
+  // Recompute when content changes (so the H1 stays in sync) or when the caller
+  // sends a title (including null/empty to re-derive from H1).
+  if (hasContent || hasTitle) {
+    const sourceContent = nextContent ?? existing.content;
+    const explicit = hasTitle ? titleOverride : existing.title;
+    fields.title = resolveTitle(sourceContent, explicit);
+  }
+
+  if (hasContent && nextContent !== undefined) {
+    fields.content = nextContent;
+    fields.searchText = stripMarkdown(nextContent);
+  }
+
+  if (hasKind) {
+    fields.kind = nextKind ?? null;
+  }
+
+  const updated = await updateDocBySlug(slug, fields);
+  if (!updated) {
+    return jsonError(404, "Document not found");
+  }
+
+  revalidatePath("/");
+  revalidatePath(`/v/${slug}`);
+
+  return new Response(
+    JSON.stringify({
+      id: updated.id,
+      slug: updated.slug,
+      title: updated.title,
+      kind: updated.kind,
+      content: updated.content,
+      createdAt: updated.createdAt,
+      updatedAt: updated.updatedAt,
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    },
+  );
 }

--- a/src/app/api/docs/[slug]/route.ts
+++ b/src/app/api/docs/[slug]/route.ts
@@ -30,8 +30,10 @@ export async function DELETE(
   }
 
   const { slug } = await context.params;
-  const deleted = await deleteDocBySlug(slug);
+  const deleted = await deleteDocBySlug(slug, auth.ownerId);
   if (!deleted) {
+    // 404 covers both "doesn't exist" and "exists but you don't own it" — don't
+    // leak existence to non-owners.
     return jsonError(404, "Document not found");
   }
   revalidatePath("/");
@@ -110,7 +112,8 @@ export async function PATCH(
   }
 
   const existing = await getDocBySlug(slug);
-  if (!existing) {
+  if (!existing || existing.ownerId !== auth.ownerId) {
+    // 404 (not 403) on owner mismatch — don't leak existence to non-owners.
     return jsonError(404, "Document not found");
   }
 

--- a/src/app/edit/[slug]/page.tsx
+++ b/src/app/edit/[slug]/page.tsx
@@ -21,7 +21,7 @@ export default async function EditPage({ params }: PageProps) {
 
   const { slug } = await params;
   const doc = await getDocBySlug(slug);
-  if (!doc) notFound();
+  if (!doc || doc.ownerId !== user.id) notFound();
 
   return (
     <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-8 sm:px-6 sm:py-12">

--- a/src/app/edit/[slug]/page.tsx
+++ b/src/app/edit/[slug]/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { isEmailAllowed } from "@/lib/access";
+import { getDocBySlug } from "@/lib/db";
+import { EditForm } from "@/components/edit-form";
+
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export const metadata = {
+  title: "Edit",
+  robots: { index: false, follow: false },
+};
+
+export default async function EditPage({ params }: PageProps) {
+  const { user } = await withAuth();
+  if (!user) redirect("/auth");
+  if (!isEmailAllowed(user.email)) redirect("/");
+
+  const { slug } = await params;
+  const doc = await getDocBySlug(slug);
+  if (!doc) notFound();
+
+  return (
+    <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
+      <header className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight">Edit</h1>
+        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+          /v/{doc.slug}
+        </p>
+      </header>
+      <EditForm
+        slug={doc.slug}
+        initialContent={doc.content}
+        initialTitle={doc.title}
+        initialKind={doc.kind}
+      />
+    </main>
+  );
+}

--- a/src/components/doc-list.tsx
+++ b/src/components/doc-list.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { listDocs } from "@/lib/db";
 import { DeleteButton } from "@/components/delete-button";
+import { EditLink } from "@/components/edit-link";
 
 const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
@@ -35,7 +36,10 @@ export async function DocList({ ownerId }: { ownerId: string }) {
               {DATE_FORMAT.format(doc.createdAt)} · /v/{doc.slug}
             </p>
           </div>
-          <DeleteButton slug={doc.slug} title={doc.title} />
+          <div className="flex items-center gap-1">
+            <EditLink slug={doc.slug} title={doc.title} />
+            <DeleteButton slug={doc.slug} title={doc.title} />
+          </div>
         </li>
       ))}
     </ul>

--- a/src/components/edit-form.tsx
+++ b/src/components/edit-form.tsx
@@ -68,7 +68,6 @@ export function EditForm({ slug, initialContent, initialTitle, initialKind }: Pr
 
     startTransition(() => {
       router.push(`/v/${slug}`);
-      router.refresh();
     });
   }
 
@@ -79,6 +78,7 @@ export function EditForm({ slug, initialContent, initialTitle, initialKind }: Pr
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         placeholder="Title (clear to re-derive from first heading)"
+        aria-label="Title"
         className="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm shadow-sm placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:placeholder:text-zinc-500"
       />
       <input
@@ -86,6 +86,7 @@ export function EditForm({ slug, initialContent, initialTitle, initialKind }: Pr
         value={kind}
         onChange={(e) => setKind(e.target.value)}
         placeholder="Kind (optional, e.g. note, rep, synthesis)"
+        aria-label="Kind (optional)"
         className="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm shadow-sm placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:placeholder:text-zinc-500"
       />
       <textarea
@@ -93,6 +94,7 @@ export function EditForm({ slug, initialContent, initialTitle, initialKind }: Pr
         onChange={(e) => setContent(e.target.value)}
         rows={20}
         spellCheck={false}
+        aria-label="Markdown content"
         className="block w-full resize-y rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono text-sm shadow-sm placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:placeholder:text-zinc-500"
       />
       <div className="flex flex-wrap items-center gap-3">

--- a/src/components/edit-form.tsx
+++ b/src/components/edit-form.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+const MAX_BYTES = 1024 * 1024;
+
+type Props = {
+  slug: string;
+  initialContent: string;
+  initialTitle: string;
+  initialKind: string | null;
+};
+
+export function EditForm({ slug, initialContent, initialTitle, initialKind }: Props) {
+  const [content, setContent] = useState(initialContent);
+  const [title, setTitle] = useState(initialTitle);
+  const [kind, setKind] = useState(initialKind ?? "");
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const dirty =
+    content !== initialContent ||
+    title !== initialTitle ||
+    kind !== (initialKind ?? "");
+
+  async function save() {
+    if (!content.trim()) {
+      toast.error("Content is empty");
+      return;
+    }
+    if (new Blob([content]).size > MAX_BYTES) {
+      toast.error("Content exceeds 1MB limit");
+      return;
+    }
+
+    const payload: { content?: string; title?: string | null; kind?: string | null } = {};
+    if (content !== initialContent) payload.content = content;
+    if (title !== initialTitle) payload.title = title.trim() || null;
+    if (kind !== (initialKind ?? "")) payload.kind = kind.trim() || null;
+
+    if (Object.keys(payload).length === 0) return;
+
+    let response: Response;
+    try {
+      response = await fetch(`/api/docs/${slug}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    } catch {
+      toast.error("Network error");
+      return;
+    }
+
+    if (!response.ok) {
+      let message = `Save failed (${response.status})`;
+      try {
+        const data = await response.json();
+        if (data?.error) message = data.error;
+      } catch {
+        // ignore JSON parse failure
+      }
+      toast.error(message);
+      return;
+    }
+
+    startTransition(() => {
+      router.push(`/v/${slug}`);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Title (clear to re-derive from first heading)"
+        className="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm shadow-sm placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:placeholder:text-zinc-500"
+      />
+      <input
+        type="text"
+        value={kind}
+        onChange={(e) => setKind(e.target.value)}
+        placeholder="Kind (optional, e.g. note, rep, synthesis)"
+        className="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm shadow-sm placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:placeholder:text-zinc-500"
+      />
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        rows={20}
+        spellCheck={false}
+        className="block w-full resize-y rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono text-sm shadow-sm placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:placeholder:text-zinc-500"
+      />
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={save}
+          disabled={isPending || !content.trim() || !dirty}
+          className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          {isPending ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push("/")}
+          className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-900"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/edit-link.tsx
+++ b/src/components/edit-link.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export function EditLink({ slug, title }: { slug: string; title: string }) {
+  return (
+    <Link
+      href={`/edit/${slug}`}
+      aria-label={`Edit ${title}`}
+      prefetch={false}
+      className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-4 w-4"
+        aria-hidden="true"
+      >
+        <path d="M12 20h9" />
+        <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+      </svg>
+    </Link>
+  );
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -133,8 +133,13 @@ export async function updateDocBySlug(
   return row ? rowToDoc(row) : null;
 }
 
-export async function deleteDocBySlug(slug: string): Promise<boolean> {
-  const result = await sql`DELETE FROM docs WHERE slug = ${slug}`;
+export async function deleteDocBySlug(
+  slug: string,
+  ownerId: string,
+): Promise<boolean> {
+  const result = await sql`
+    DELETE FROM docs WHERE slug = ${slug} AND owner_id = ${ownerId}
+  `;
   return (result.rowCount ?? 0) > 0;
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -91,6 +91,48 @@ export async function insertDoc(input: {
   return rowToDoc(row);
 }
 
+export type UpdateDocFields = {
+  title?: string;
+  content?: string;
+  searchText?: string;
+  kind?: string | null;
+};
+
+export async function updateDocBySlug(
+  slug: string,
+  fields: UpdateDocFields,
+): Promise<Doc | null> {
+  const sets: string[] = [];
+  const values: unknown[] = [];
+  function bind(value: unknown): string {
+    values.push(value);
+    return `$${values.length}`;
+  }
+  if (fields.title !== undefined) sets.push(`title = ${bind(fields.title)}`);
+  if (fields.content !== undefined) sets.push(`content = ${bind(fields.content)}`);
+  if (fields.searchText !== undefined)
+    sets.push(`search_text = ${bind(fields.searchText)}`);
+  if (fields.kind !== undefined) sets.push(`kind = ${bind(fields.kind)}`);
+
+  if (sets.length === 0) {
+    // Nothing to update — caller shouldn't reach here, but treat as a read.
+    return getDocBySlug(slug);
+  }
+
+  sets.push(`updated_at = now()`);
+  const slugParam = bind(slug);
+  const text = `
+    UPDATE docs
+    SET ${sets.join(", ")}
+    WHERE slug = ${slugParam}
+    RETURNING id, slug, owner_id, title, content, kind, search_text, created_at, updated_at
+  `;
+
+  const result = await sql.query<DocRow>(text, values);
+  const row = result.rows[0];
+  return row ? rowToDoc(row) : null;
+}
+
 export async function deleteDocBySlug(slug: string): Promise<boolean> {
   const result = await sql`DELETE FROM docs WHERE slug = ${slug}`;
   return (result.rowCount ?? 0) > 0;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,5 +3,5 @@ import { authkitProxy } from "@workos-inc/authkit-nextjs";
 export default authkitProxy();
 
 export const config = {
-  matcher: ["/", "/api/upload", "/api/docs/:slug*", "/api/list"],
+  matcher: ["/", "/edit/:slug*", "/api/upload", "/api/docs/:slug*", "/api/list"],
 };


### PR DESCRIPTION
Closes #7.

## Summary
- New `PATCH /api/docs/[slug]` accepts JSON `{content?, title?, kind?}` (at least one required). Bearer-or-session auth, 404 unknown, 200 with `{id, slug, title, kind, content, createdAt, updatedAt}` on success. 1 MB content cap, empty/whitespace content rejected. Slug stays immutable (any `slug` field in the body is ignored). Last-write-wins (no `If-Match`/ETag, no revisions) per the locked PRD decisions.
- `db.updateDocBySlug` builds a parameterized partial UPDATE; `search_text` (app-side) and `search_vector` (existing trigger) are rebuilt whenever `content` changes, so search reflects the new body immediately.
- New `/edit/[slug]` server-component page (covered by AuthKit middleware via the `proxy.ts` matcher) prefills title, kind, and body. Save PATCHes the diff (only changed fields) and routes to `/v/[slug]` so you land on the rendered result; errors surface as toasts, the success path is silent. Cancel returns to `/`.
- Dashboard rows in `<DocList>` get a pencil edit link next to the trash icon.
- `revalidatePath('/')` and `revalidatePath('/v/<slug>')` fire from PATCH and DELETE so the home dashboard and the public view page reflect changes without a hard refresh.
- `~/.claude/skills/md-upload/SKILL.md` (operator-global) updated with PATCH usage and the title-rederivation rule.

## Title rederivation rule
PATCH only mutates fields you send. To re-derive the title from a (possibly new) H1 in the body, send `{"title": null}` — optionally alongside `content`. Sending only `content` deliberately preserves the existing title (so a custom title isn't clobbered by a heading edit).

## Acceptance criteria
- [x] `PATCH /api/docs/[slug]` accepts JSON `{content?, title?}` (at least one required) — also accepts `kind`
- [x] Same auth as upload/delete: bearer or session
- [x] Returns 404 for unknown slug
- [x] Returns 200 with the updated doc shape on success
- [x] Updating either field rebuilds `search_text` (app-side) and `search_vector` (trigger)
- [x] Slug remains immutable on PATCH
- [x] Concurrency: last-write-wins; no `If-Match`/ETag in v1
- [x] No revision history; PATCH overwrites
- [x] UI: each row in the recent-uploads list has an "edit" affordance (pencil icon) alongside the trash
- [x] Edit page (`/edit/[slug]`) loads existing content/title (and kind) into the form; "Save" PATCHes
- [x] View URL after edit returns updated content; OG metadata reflects new title (verified by curl on `/v/<slug>` after PATCH)
- [x] On save, route to the rendered `/v/<slug>` (per follow-up feedback) instead of `/`

## Validation
15-step bearer smoke against localhost (which is the shared Neon DB) — all pass:
- PATCH content only (title preserved); PATCH `title=null` (rederive from H1); PATCH explicit title; PATCH content + `title=null`
- PATCH `kind` set / clear
- 400 on empty body / empty content / non-string content
- 404 unknown slug
- 401 no auth
- FTS rebuild: search reflects new body, drops old terms
- Slug field in body ignored (immutability)
- `/v/<slug>` HTML reflects updated title via `revalidatePath`
- `/edit/<slug>` redirects unauth requests (307) — confirms proxy matcher coverage

UI verified manually in the dashboard and edit flow (pencil icon, prefilled fields, Save → `/v/<slug>`, no toast on success, error toasts intact).

`pnpm exec tsc --noEmit` and `pnpm lint` both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to edit documentation documents with dedicated edit pages
  * Edit forms allow updating document content, title, and document type with validation
  * New edit buttons in the document list for quick access to editing
  * Updated documents automatically refresh across the application
  * Includes size limits to ensure optimal performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->