### PR TITLE
feat: shared site header + view-page raw link (#17)

### DIFF
--- a/src/app/edit/[slug]/page.tsx
+++ b/src/app/edit/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
 import { getDocBySlug } from "@/lib/db";
 import { EditForm } from "@/components/edit-form";
+import { SiteHeader } from "@/components/site-header";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -24,19 +25,22 @@ export default async function EditPage({ params }: PageProps) {
   if (!doc || doc.ownerId !== user.id) notFound();
 
   return (
-    <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
-      <header className="mb-8">
-        <h1 className="text-2xl font-semibold tracking-tight">Edit</h1>
-        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
-          /v/{doc.slug}
-        </p>
-      </header>
-      <EditForm
-        slug={doc.slug}
-        initialContent={doc.content}
-        initialTitle={doc.title}
-        initialKind={doc.kind}
-      />
-    </main>
+    <>
+      <SiteHeader />
+      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
+        <header className="mb-8">
+          <h1 className="text-2xl font-semibold tracking-tight">Edit</h1>
+          <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+            /v/{doc.slug}
+          </p>
+        </header>
+        <EditForm
+          slug={doc.slug}
+          initialContent={doc.content}
+          initialTitle={doc.title}
+          initialKind={doc.kind}
+        />
+      </main>
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { withAuth, signOut } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
 import { UploadForm } from "@/components/upload-form";
 import { DocList } from "@/components/doc-list";
+import { SiteHeader } from "@/components/site-header";
 
 async function signOutAction() {
   "use server";
@@ -38,29 +39,20 @@ export default async function Home() {
   }
 
   return (
-    <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
-      <header className="mb-8 flex items-center justify-between gap-4">
-        <h1 className="text-2xl font-semibold tracking-tight">md</h1>
-        <form action={signOutAction}>
-          <button
-            type="submit"
-            className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs font-medium hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-900"
-          >
-            Sign out
-          </button>
-        </form>
-      </header>
+    <>
+      <SiteHeader />
+      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
+        <section className="mb-10">
+          <UploadForm />
+        </section>
 
-      <section className="mb-10">
-        <UploadForm />
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-500">
-          Recent uploads
-        </h2>
-        <DocList ownerId={user.id} />
-      </section>
-    </main>
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-500">
+            Recent uploads
+          </h2>
+          <DocList ownerId={user.id} />
+        </section>
+      </main>
+    </>
   );
 }

--- a/src/app/v/[slug]/page.tsx
+++ b/src/app/v/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getDocBySlug } from "@/lib/db";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
+import { SiteHeader } from "@/components/site-header";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -47,15 +48,21 @@ export default async function ViewPage({ params }: PageProps) {
   if (!doc) notFound();
 
   return (
-    <main className="mx-auto w-full max-w-3xl px-6 py-10">
-      <article className="prose prose-zinc dark:prose-invert max-w-none prose-pre:bg-transparent prose-pre:p-0">
-        <MarkdownRenderer content={doc.content} />
-      </article>
-      <footer className="mt-16 border-t border-zinc-200 pt-6 text-xs text-zinc-500 dark:border-zinc-800 dark:text-zinc-500">
-        <Link href="/" className="hover:underline">
-          md.niftymonkey.dev
-        </Link>
-      </footer>
-    </main>
+    <>
+      <SiteHeader />
+      <main className="mx-auto w-full max-w-3xl px-6 py-10">
+        <article className="prose prose-zinc dark:prose-invert max-w-none prose-pre:bg-transparent prose-pre:p-0">
+          <MarkdownRenderer content={doc.content} />
+        </article>
+        <footer className="mt-16 flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t border-zinc-200 pt-6 text-xs text-zinc-500 dark:border-zinc-800 dark:text-zinc-500">
+          <Link href={`/api/raw/${doc.slug}`} className="hover:underline">
+            View raw
+          </Link>
+          <Link href="/" className="hover:underline">
+            md.niftymonkey.dev
+          </Link>
+        </footer>
+      </main>
+    </>
   );
 }

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { withAuth, signOut } from "@workos-inc/authkit-nextjs";
+import { isEmailAllowed } from "@/lib/access";
+
+async function signOutAction() {
+  "use server";
+  await signOut();
+}
+
+export async function SiteHeader() {
+  const { user } = await withAuth();
+
+  if (!user || !isEmailAllowed(user.email)) return null;
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-zinc-200 bg-white/80 backdrop-blur dark:border-zinc-800 dark:bg-zinc-950/80">
+      <div className="mx-auto flex h-14 w-full max-w-3xl items-center justify-between gap-4 px-4 sm:px-6">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm font-semibold tracking-tight text-zinc-900 hover:text-zinc-600 dark:text-zinc-100 dark:hover:text-zinc-400"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-5 w-5"
+            aria-hidden="true"
+          >
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <path d="M14 2v6h6" />
+            <path d="M9 13l2 2 4-4" />
+          </svg>
+          <span>md</span>
+        </Link>
+        <form action={signOutAction}>
+          <button
+            type="submit"
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs font-medium hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-900"
+          >
+            Sign out
+          </button>
+        </form>
+      </div>
+    </header>
+  );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,5 +3,12 @@ import { authkitProxy } from "@workos-inc/authkit-nextjs";
 export default authkitProxy();
 
 export const config = {
-  matcher: ["/", "/edit/:slug*", "/api/upload", "/api/docs/:slug*", "/api/list"],
+  matcher: [
+    "/",
+    "/v/:slug*",
+    "/edit/:slug*",
+    "/api/upload",
+    "/api/docs/:slug*",
+    "/api/list",
+  ],
 };


### PR DESCRIPTION
Closes #17.

## Summary
- New shared `<SiteHeader />` server component (sticky, border-b, backdrop-blur — modeled on the `niftymonkey/brief` header). Brand on the left (file icon + "md" linking to `/`), sign-out on the right. Renders only when the viewer has a session AND is on the email allow list, so the public share view stays clean for anonymous viewers and not-allowlisted users.
- `<SiteHeader />` adopted on `/`, `/v/[slug]`, and `/edit/[slug]` so the three rendered pages now share one header.
- `/v/[slug]` footer gets a "View raw" link to `/api/raw/<slug>` so humans and LLM consumers can self-discover the lossless markdown URL from the rendered page. Footer is `justify-between`: "View raw" left, "md.niftymonkey.dev" right.
- All three pages bumped to `max-w-3xl` so the header band, the prose column, the upload form, and the edit form all line up at the same width.
- `/v/:slug*` added to the AuthKit proxy matcher so `withAuth()` works there (required for the auth-aware header). Public access is unchanged — the route handler doesn't gate on auth.

## Acceptance criteria
- [x] "View raw" link rendered on `/v/[slug]`, in the footer next to "md.niftymonkey.dev"
- [x] Link target is `/api/raw/<slug>` for the current doc
- [x] Default content type `text/markdown` (verified via `Content-Type: text/markdown; charset=utf-8` on the linked endpoint)
- [x] Authed viewer sees a header at the top with a branded "md" link back to `/`
- [x] Anonymous viewer sees no header — public share view stays clean (verified via curl: no `<header>` in the unauth HTML)
- [x] Header consistent with `/` (it IS the same component now — same height, same brand styling)
- [x] Both additions visible and usable on mobile and desktop (header is `sticky top-0 z-50`, content uses standard responsive padding)
- [x] Neither addition disrupts the prose layout

## Validation
Curl smoke against localhost (auth-irrelevant cases) — all pass:
- Unauth `/v/<slug>` → 200, no `<header>` in HTML, "View raw" link present in footer.
- View-raw target → `Content-Type: text/markdown; charset=utf-8`.
- Unknown slug → 404.

Browser-verified manually (signed in):
- Sticky header renders on `/`, `/v/[slug]`, `/edit/[slug]`.
- Brand link returns to `/`. Sign-out works.
- Header band aligns with the prose / form columns at all widths.
- Anonymous incognito view of `/v/[slug]` correctly omits the header.

`pnpm exec tsc --noEmit` and `pnpm lint` both clean.