### PR TITLE
feat: personal API tokens replace shared MD_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,7 @@ ALLOWED_EMAILS=
 # Vercel Postgres connection string (Neon-backed)
 POSTGRES_URL=
 
-# md API key — bearer token for curl/agents. Generate: openssl rand -hex 32
-MD_API_KEY=
-
-# WorkOS user id stamped on bearer-uploaded docs so they appear in your listing.
-# Get this after your first WorkOS login (visible in WorkOS dashboard or session).
-MD_API_OWNER_ID=
+# Bearer auth uses personal API tokens generated at /settings (after sign-in).
+# No env-var-based shared secret is required for the API to function.
+# For curl/agents, paste the token shown at creation into your shell:
+#   export MD_API_KEY=mdk_...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 When a piece of UI depends on a value only the client knows (`localStorage`, `prefers-color-scheme`, etc.) and that value affects layout, visibility, or visual state, follow this pattern. Skipping any step reintroduces the flash.
 
-1. **Inline script in `<head>`** (via `dangerouslySetInnerHTML` in `src/app/layout.tsx`) reads the value synchronously and sets a `data-*` attribute on `<html>`. Runs before first paint.
+1. **Inline script via `next/script` with `strategy="beforeInteractive"`** in `src/app/layout.tsx` reads the value synchronously and sets a `data-*` attribute on `<html>`. Next.js hoists the script content into the document `<head>` and executes it before hydration / first paint, while keeping it out of React's render tree (avoids the React 19 "Encountered a script tag while rendering React component" dev warning that fires for raw `<script dangerouslySetInnerHTML>` children).
 2. **CSS keyed on the data attribute** drives the visible difference: `display`, custom-property values (`--md-article-max`), color tokens, etc. First paint is correct.
 3. **Server renders every state.** When a UI region differs based on a flippable setting, render all variants in JSX and let CSS hide the wrong one. Do not gate the initial JSX on React state — that state defaults to the server-render value, then flips after `useEffect` reads `localStorage`, which is the flash.
 4. **Do not derive visuals from React state** for things step 3 controls. If a component only appears in one logical state (e.g., a "Show outline" button that only renders when the outline is hidden), hardcode its visual props rather than reading state that will flip post-hydration.
@@ -16,6 +16,8 @@ When a piece of UI depends on a value only the client knows (`localStorage`, `pr
 
 Current keys: `data-width` (reading/wide), `data-outline-hidden`, `data-theme` (dev-only switcher). Extend the inline script for new settings; mirror the data-attribute selector pattern in `globals.css`.
 
-Why not `useEffect` / `useLayoutEffect`? `useEffect` runs after first paint, so the wrong state is visible briefly. `useLayoutEffect` does not run during SSR, so the server HTML still reflects the default. Only a synchronous inline script in `<head>` executes before first paint.
+Why not `useEffect` / `useLayoutEffect`? `useEffect` runs after first paint, so the wrong state is visible briefly. `useLayoutEffect` does not run during SSR, so the server HTML still reflects the default. Only a synchronous inline script that runs before first paint avoids the flash — `next/script` `beforeInteractive` is one such mechanism.
 
-If the project ever adopts a strict CSP that blocks inline scripts, switch to cookie-based persistence: read on the server in `layout.tsx`, render `<html data-*="...">` directly. Same data attributes, same CSS, no `dangerouslySetInnerHTML`.
+Why `next/script` instead of a raw `<script dangerouslySetInnerHTML>`? Both produce the same end-state HTML (script in `<head>`, runs before first paint). `next/script` keeps the script out of React's render tree, so React 19 doesn't log the "Encountered a script tag while rendering React component" dev warning. Adding `suppressHydrationWarning` to silence that warning would just hide it without solving the cause; `next/script` solves the cause by moving the element out of React's reconciliation.
+
+If the project ever adopts a strict CSP that blocks inline scripts, switch to cookie-based persistence: read on the server in `layout.tsx`, render `<html data-*="...">` directly. Same data attributes, same CSS, no inline script.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,17 @@ In order:
 
 ## API surface
 
-All endpoints accept either `Authorization: Bearer $MD_API_KEY` or a valid WorkOS session cookie unless marked public. Auth handler: `src/lib/auth.ts` — bearer first, session fallback.
+All endpoints accept either `Authorization: Bearer <personal-token>` (created at `/settings`) or a valid WorkOS session cookie unless marked public. Tokens are stored as sha256 hashes in `api_tokens`; `requireAuth` (in `src/lib/auth.ts`) tries bearer first, then session. Token-management endpoints under `/api/tokens` are session-only — bearer is rejected to prevent token-spawn-from-leaked-token escalation.
 
 | Method | Path | Auth | Notes |
 |---|---|---|---|
 | `POST` | `/api/upload` | bearer or session | Raw `text/markdown` body or JSON `{content, title?}`. Title resolves: explicit → first H1 → "Untitled". 1 MB cap. |
 | `DELETE` | `/api/docs/[slug]` | bearer or session | 204 on success, 404 unknown. |
-| `GET` | `/api/list` | bearer or session | `?limit=` (max 100), `?cursor=`, `?search=`. Returns `{docs, nextCursor}`, owner-scoped. |
+| `PATCH` | `/api/docs/[slug]` | bearer or session | Partial update of `content`, `title`, `kind`. |
+| `GET` | `/api/list` | bearer or session | `?limit=` (max 100), `?cursor=`, `?search=`, `?kind=`. Returns `{docs, nextCursor}`, owner-scoped. |
+| `POST` | `/api/tokens` | session only | `{name}`. Returns plaintext token once. |
+| `GET` | `/api/tokens` | session only | Lists active tokens (no plaintext). |
+| `DELETE` | `/api/tokens/[id]` | session only | Sets `revoked_at` on the row. |
 | `GET` | `/api/raw/[slug]` | public | `text/markdown` by default; JSON if `Accept: application/json`. |
 | `GET` | `/v/[slug]` | public | Server-rendered page with OG metadata + `noindex, nofollow`. |
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Required env vars are listed in `.env.example`. Copy it to `.env.local` and fill
 
 ## API
 
+The bearer credential is a personal API token generated from `/settings` after signing in. Each token is shown only at creation; the server stores a sha256 hash. Lost tokens can be revoked and replaced but not recovered.
+
+Export your token in the shell:
+
+```bash
+export MD_API_KEY=mdk_...
+```
+
 Upload via curl:
 
 ```bash

--- a/docs/test-scenarios.md
+++ b/docs/test-scenarios.md
@@ -2,7 +2,7 @@
 
 Reference for what behavior to cover when automated tests come online. Each scenario was verified manually via curl against a local dev server during the PR that introduced it; capture them here so we don't regress on them silently.
 
-Until there's a test runner, the curl recipes below are runnable as-is against `http://localhost:3000`. Generate a personal API token at `/settings` and export it as `MD_API_KEY=mdk_...` for the bearer-flow recipes. The local DB is the shared Neon DB until #8 separates environments — be mindful of test data and clean up after yourself.
+Vitest covers the auth + token data layer (`pnpm test`); higher-level scenarios still rely on manual curl recipes runnable as-is against `http://localhost:3000`. Generate a personal API token at `/settings` and export it as `MD_API_KEY=mdk_...` for the bearer-flow recipes. The local DB is the shared Neon DB until #8 separates environments — be mindful of test data and clean up after yourself.
 
 For ownership scenarios that need a doc owned by a *different* user, insert directly via `@vercel/postgres` from a tsx script (one-off, not committed). Example shape:
 

--- a/docs/test-scenarios.md
+++ b/docs/test-scenarios.md
@@ -2,7 +2,7 @@
 
 Reference for what behavior to cover when automated tests come online. Each scenario was verified manually via curl against a local dev server during the PR that introduced it; capture them here so we don't regress on them silently.
 
-Until there's a test runner, the curl recipes below are runnable as-is against `http://localhost:3000` with `MD_API_KEY` and `MD_API_OWNER_ID` set. The local DB is the shared Neon DB until #8 separates environments — be mindful of test data and clean up after yourself.
+Until there's a test runner, the curl recipes below are runnable as-is against `http://localhost:3000`. Generate a personal API token at `/settings` and export it as `MD_API_KEY=mdk_...` for the bearer-flow recipes. The local DB is the shared Neon DB until #8 separates environments — be mindful of test data and clean up after yourself.
 
 For ownership scenarios that need a doc owned by a *different* user, insert directly via `@vercel/postgres` from a tsx script (one-off, not committed). Example shape:
 
@@ -29,7 +29,7 @@ Cleanup that row afterward — non-owner DELETE from the API will (correctly) re
 - Title resolves: explicit override → first H1 → `"Untitled"`
 - `X-Title` header honors ASCII titles; UTF-8 (em-dash, accents, emoji) round-trips correctly only via JSON body
 - `X-Kind` header normalizes (trim + lowercase) just like JSON body
-- Bearer-uploaded docs land under `MD_API_OWNER_ID`; session-uploaded docs land under `user.id`
+- Bearer-uploaded docs land under the `owner_id` of the token's row; session-uploaded docs land under `user.id` (typically the same value for an operator with one token)
 
 ## Edit (`PATCH /api/docs/[slug]`)
 
@@ -93,5 +93,6 @@ Cleanup that row afterward — non-owner DELETE from the API will (correctly) re
 ## Cross-cutting
 
 - Bearer and session auth paths both use `requireAuth` and produce the same `auth.ownerId`
-- Bearer flow: `MD_API_KEY` and `MD_API_OWNER_ID` are trimmed at read-time (defense against trailing newlines from `echo "..." | vercel env add`)
+- Bearer flow: a sha256 hash of the incoming token is looked up in `api_tokens`; revoked rows (`revoked_at IS NOT NULL`) reject as 401
+- Token-management endpoints (`/api/tokens*`) are session-only and reject any non-empty `Authorization` header
 - Public endpoints (`/v/<slug>`, `/api/raw/<slug>`) intentionally remain unscoped — shareable URLs are the point

--- a/migrations/003_create_api_tokens_table.sql
+++ b/migrations/003_create_api_tokens_table.sql
@@ -1,0 +1,21 @@
+-- 003_create_api_tokens_table.sql
+-- Personal API tokens (issue #14). Replaces the single shared MD_API_KEY env-var
+-- with per-user, hashed, revocable tokens. The bearer auth path in
+-- src/lib/auth.ts looks up the sha256 of the incoming token in token_hash.
+-- The 8-char prefix is stored for UI display, plaintext is never persisted.
+-- The partial index supports owner-scoped lists of active tokens.
+
+CREATE TABLE api_tokens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id text NOT NULL,
+  name text NOT NULL,
+  token_hash text NOT NULL UNIQUE,
+  prefix text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  last_used_at timestamptz,
+  revoked_at timestamptz
+);
+
+CREATE INDEX idx_api_tokens_owner_active
+  ON api_tokens (owner_id, created_at DESC)
+  WHERE revoked_at IS NULL;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "migrate": "tsx scripts/migrate.ts"
+    "migrate": "tsx scripts/migrate.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@shikijs/rehype": "^4.0.2",
@@ -33,11 +35,13 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/remove-markdown": "^0.3.4",
+    "@vitest/ui": "^4.1.5",
     "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@types/remove-markdown':
         specifier: ^0.3.4
         version: 0.3.4
+      '@vitest/ui':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -90,6 +93,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@20.19.39)(@vitest/ui@4.1.5)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
 packages:
 
@@ -573,6 +579,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@neondatabase/serverless@0.9.5':
     resolution: {integrity: sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==}
 
@@ -646,6 +658,104 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -687,6 +797,9 @@ packages:
   '@sindresorhus/fnv1a@3.1.0':
     resolution: {integrity: sha512-KV321z5m/0nuAg83W1dPLy85HpHDk7Sdi4fJbwvacWsEhAh+rZUW4ZfGcXmUIvjZg4ss2bcwNlRhJ7GBEUG08w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -787,6 +900,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -882,6 +998,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1098,6 +1217,40 @@ packages:
     engines: {node: '>=18.14'}
     deprecated: '@vercel/postgres is deprecated. If you are setting up a new database, you can choose an alternate storage solution from the Vercel Marketplace. If you had an existing Vercel Postgres database, it should have been migrated to Neon as a native Vercel integration. You can find more details and the guide to migrate to Neon''s SDKs here: https://neon.com/docs/guides/vercel-postgres-transition-guide'
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/ui@4.1.5':
+    resolution: {integrity: sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==}
+    peerDependencies:
+      vitest: 4.1.5
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   '@workos-inc/authkit-nextjs@4.0.1':
     resolution: {integrity: sha512-lSpvQCzazHz1iBS2gtT3o4NQRiman3CjOAvSbU50KeoSYddx/z0hc73WDL9TC+UNTIZ7R7/KBc2BrOrWJ/MiVQ==}
     engines: {node: '>=22.11.0'}
@@ -1165,6 +1318,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1241,6 +1398,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1579,6 +1740,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1731,12 +1895,19 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1765,6 +1936,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2407,6 +2581,10 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2494,6 +2672,9 @@ packages:
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
@@ -2703,6 +2884,11 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -2783,6 +2969,13 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2792,6 +2985,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2868,6 +3067,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -2876,9 +3078,17 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3003,6 +3213,90 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -3042,6 +3336,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3496,6 +3795,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@neondatabase/serverless@0.9.5':
     dependencies:
       '@types/pg': 8.11.6
@@ -3543,6 +3849,61 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@polka/url@1.0.0-next.29': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -3596,6 +3957,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/fnv1a@3.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3679,6 +4042,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -3800,6 +4168,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -4015,6 +4385,58 @@ snapshots:
     transitivePeerDependencies:
       - utf-8-validate
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/ui@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      fflate: 0.8.2
+      flatted: 3.4.2
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@20.19.39)(@vitest/ui@4.1.5)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@workos-inc/authkit-nextjs@4.0.1(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
       '@sindresorhus/fnv1a': 3.1.0
@@ -4121,6 +4543,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -4188,6 +4612,8 @@ snapshots:
   caniuse-lite@1.0.30001791: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4604,6 +5030,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -4865,9 +5293,15 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -4892,6 +5326,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5769,6 +6205,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -5857,6 +6295,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   obuf@1.1.2: {}
+
+  obug@2.1.1: {}
 
   oniguruma-parser@0.12.2: {}
 
@@ -6107,6 +6547,27 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -6246,11 +6707,23 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -6343,6 +6816,8 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
@@ -6350,9 +6825,13 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@3.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  totalist@3.0.1: {}
 
   trim-lines@3.0.1: {}
 
@@ -6528,6 +7007,48 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.39
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+
+  vitest@4.1.5(@types/node@20.19.39)(@vitest/ui@4.1.5)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -6589,6 +7110,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/app/api/tokens/[id]/route.ts
+++ b/src/app/api/tokens/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from "next/server";
+import { requireSessionAuth } from "@/lib/auth";
+import { revokeToken } from "@/lib/api-tokens";
+
+function jsonError(status: number, message: string) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireSessionAuth(req);
+  if (!auth.authenticated) return jsonError(auth.status, auth.reason);
+
+  const { id } = await context.params;
+  const ok = await revokeToken(auth.ownerId, id);
+  if (!ok) return jsonError(404, "Token not found");
+  return new Response(null, { status: 204 });
+}

--- a/src/app/api/tokens/[id]/route.ts
+++ b/src/app/api/tokens/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest } from "next/server";
 import { requireSessionAuth } from "@/lib/auth";
 import { revokeToken } from "@/lib/api-tokens";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function jsonError(status: number, message: string) {
   return new Response(JSON.stringify({ error: message }), {
     status,
@@ -17,6 +19,8 @@ export async function DELETE(
   if (!auth.authenticated) return jsonError(auth.status, auth.reason);
 
   const { id } = await context.params;
+  if (!UUID_RE.test(id)) return jsonError(404, "Token not found");
+
   const ok = await revokeToken(auth.ownerId, id);
   if (!ok) return jsonError(404, "Token not found");
   return new Response(null, { status: 204 });

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from "next/server";
+import { requireSessionAuth } from "@/lib/auth";
+import { createApiToken, listTokensForOwner } from "@/lib/api-tokens";
+
+const NAME_MAX = 64;
+
+function jsonError(status: number, message: string) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function jsonOk(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await requireSessionAuth(req);
+  if (!auth.authenticated) return jsonError(auth.status, auth.reason);
+
+  const tokens = await listTokensForOwner(auth.ownerId);
+  return jsonOk({
+    tokens: tokens.map((t) => ({
+      id: t.id,
+      name: t.name,
+      prefix: t.prefix,
+      createdAt: t.createdAt,
+      lastUsedAt: t.lastUsedAt,
+    })),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireSessionAuth(req);
+  if (!auth.authenticated) return jsonError(auth.status, auth.reason);
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return jsonError(400, "Body must be JSON");
+  }
+
+  if (typeof payload !== "object" || payload === null) {
+    return jsonError(400, "Body must be a JSON object");
+  }
+  const name = (payload as { name?: unknown }).name;
+  if (typeof name !== "string") {
+    return jsonError(400, "`name` is required");
+  }
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return jsonError(400, "`name` cannot be empty");
+  }
+  if (trimmed.length > NAME_MAX) {
+    return jsonError(400, `\`name\` is over ${NAME_MAX} characters`);
+  }
+
+  const created = await createApiToken(auth.ownerId, trimmed);
+  return jsonOk(
+    {
+      id: created.id,
+      name: created.name,
+      prefix: created.prefix,
+      plaintext: created.plaintext,
+      createdAt: created.createdAt,
+    },
+    201,
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -233,3 +233,271 @@ button:not(:disabled) {
 :root.theme-changing *::after {
   transition: none !important;
 }
+
+/* ==================== /settings ==================== */
+.settings {
+  position: relative;
+  background: var(--paper-warm);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 32px clamp(28px, 5vw, 56px);
+}
+
+.settings__watermark {
+  position: absolute;
+  top: 24px;
+  right: clamp(20px, 4vw, 40px);
+}
+
+.settings__h1 {
+  font-weight: 700;
+  font-size: 1.875rem;
+  line-height: 1.1;
+  letter-spacing: -0.025em;
+  margin-bottom: 6px;
+}
+
+.settings__sub {
+  font-size: 0.9375rem;
+  color: var(--muted);
+  margin-bottom: 32px;
+}
+
+.settings__section + .settings__section {
+  margin-top: 32px;
+}
+
+.settings__section-h {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ochre-deep);
+  margin-bottom: 14px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--ochre);
+}
+
+.settings__section-intro {
+  font-size: 0.875rem;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+
+.settings__empty {
+  font-size: 0.875rem;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+
+.settings__error {
+  margin-top: 12px;
+  font-size: 0.875rem;
+  color: var(--ochre-deep);
+}
+
+.settings__create-btn {
+  margin-top: 14px;
+  border: 1px solid var(--border);
+  background: var(--paper);
+  color: var(--ink);
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: border-color 200ms, color 200ms;
+}
+.settings__create-btn:hover {
+  border-color: var(--ochre);
+  color: var(--ochre-deep);
+}
+
+.token-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+.token-table thead th {
+  text-align: left;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 0 0 8px;
+  border-bottom: 1px solid var(--border);
+}
+.token-table thead th:last-child {
+  width: 1%;
+}
+.token-table tbody td {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+.token-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+.token-table__name {
+  font-weight: 500;
+  color: var(--ink);
+  padding-right: 24px;
+  width: auto;
+}
+.token-table__id {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  padding-right: 24px;
+  white-space: nowrap;
+  width: 1%;
+}
+.token-table__last-used {
+  color: var(--muted);
+  padding-right: 16px;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  width: 1%;
+}
+.token-table__actions {
+  text-align: right;
+}
+.token-table__revoke {
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+  border-radius: 3px;
+  transition: color 150ms, background 150ms;
+}
+.token-table__revoke:hover:not(:disabled) {
+  color: var(--ochre-deep);
+  background: var(--paper);
+}
+.token-table__revoke:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ==================== modal ==================== */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: oklch(0% 0 0 / 0.40);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+.modal {
+  width: 100%;
+  max-width: 480px;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  padding: 24px;
+}
+.modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.modal__title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.modal__desc {
+  font-size: 0.875rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.modal__label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.modal__input {
+  background: var(--paper-warm);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 10px 12px;
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.875rem;
+  color: var(--ink);
+  letter-spacing: normal;
+  text-transform: none;
+  outline: none;
+  transition: border-color 150ms;
+}
+.modal__input:focus {
+  border-color: var(--ochre);
+}
+.modal__error {
+  font-size: 0.875rem;
+  color: var(--ochre-deep);
+}
+.modal__token {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--paper-warm);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 10px 12px;
+}
+.modal__token-value {
+  flex: 1;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.8125rem;
+  color: var(--ink);
+  word-break: break-all;
+}
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.modal__btn {
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  transition: background 150ms, border-color 150ms, color 150ms, opacity 150ms;
+}
+.modal__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.modal__btn--ghost {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--ink);
+}
+.modal__btn--ghost:hover:not(:disabled) {
+  border-color: var(--ochre);
+  color: var(--ochre-deep);
+}
+.modal__btn--primary {
+  background: var(--ink);
+  color: var(--paper);
+}
+.modal__btn--primary:hover:not(:disabled) {
+  background: var(--ochre-deep);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Inter_Tight, Geist_Mono } from "next/font/google";
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
 import { DevThemeSwitcher } from "@/components/dev-theme-switcher";
 import "./globals.css";
+
+const PRE_HYDRATION_SCRIPT = `(function(){try{var w=localStorage.getItem('md.width');if(w==='wide')document.documentElement.setAttribute('data-width','wide');var o=localStorage.getItem('md.outline.shown');if(o==='false')document.documentElement.setAttribute('data-outline-hidden','1');var t=localStorage.getItem('md.dev-theme');if(t==='light'||t==='dark'){document.documentElement.setAttribute('data-theme',t);document.documentElement.setAttribute('data-dev-theme',t);}var ua=navigator.userAgent||'';var p=(navigator.userAgentData&&navigator.userAgentData.platform)||'';if(/Mac|iPhone|iPad/.test(ua)||/macOS|iOS/.test(p))document.documentElement.setAttribute('data-platform','mac');}catch(e){}})();`;
 
 const interTight = Inter_Tight({
   variable: "--font-inter-tight",
@@ -30,14 +33,10 @@ export default function RootLayout({
       className={`${interTight.variable} ${geistMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <head>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(){try{var w=localStorage.getItem('md.width');if(w==='wide')document.documentElement.setAttribute('data-width','wide');var o=localStorage.getItem('md.outline.shown');if(o==='false')document.documentElement.setAttribute('data-outline-hidden','1');var t=localStorage.getItem('md.dev-theme');if(t==='light'||t==='dark'){document.documentElement.setAttribute('data-theme',t);document.documentElement.setAttribute('data-dev-theme',t);}var ua=navigator.userAgent||'';var p=(navigator.userAgentData&&navigator.userAgentData.platform)||'';if(/Mac|iPhone|iPad/.test(ua)||/macOS|iOS/.test(p))document.documentElement.setAttribute('data-platform','mac');}catch(e){}})();`,
-          }}
-        />
-      </head>
       <body className="min-h-full flex flex-col bg-paper text-ink">
+        <Script id="md-pre-hydration" strategy="beforeInteractive">
+          {PRE_HYDRATION_SCRIPT}
+        </Script>
         <AuthKitProvider>{children}</AuthKitProvider>
         {process.env.NODE_ENV === "development" && <DevThemeSwitcher />}
       </body>

--- a/src/app/settings/_components/tokens-section.tsx
+++ b/src/app/settings/_components/tokens-section.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+const RELATIVE_DIVISIONS: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> = [
+  { unit: "year", ms: 365 * 24 * 60 * 60 * 1000 },
+  { unit: "month", ms: 30 * 24 * 60 * 60 * 1000 },
+  { unit: "day", ms: 24 * 60 * 60 * 1000 },
+  { unit: "hour", ms: 60 * 60 * 1000 },
+  { unit: "minute", ms: 60 * 1000 },
+  { unit: "second", ms: 1000 },
+];
+
+const RELATIVE_FORMATTER = new Intl.RelativeTimeFormat("en-US", {
+  numeric: "auto",
+});
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "never";
+  const target = new Date(iso).getTime();
+  if (Number.isNaN(target)) return "—";
+  const delta = target - Date.now();
+  if (Math.abs(delta) < 30 * 1000) return "just now";
+  for (const { unit, ms } of RELATIVE_DIVISIONS) {
+    if (Math.abs(delta) >= ms || unit === "second") {
+      return RELATIVE_FORMATTER.format(Math.round(delta / ms), unit);
+    }
+  }
+  return "just now";
+}
+
+type TokenRow = {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+};
+
+type CreatedToken = {
+  id: string;
+  name: string;
+  prefix: string;
+  plaintext: string;
+  createdAt: string;
+};
+
+export function TokensSection({
+  initialTokens,
+}: {
+  initialTokens: TokenRow[];
+}) {
+  const [tokens, setTokens] = useState<TokenRow[]>(initialTokens);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [created, setCreated] = useState<CreatedToken | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+
+  function closeModal() {
+    setModalOpen(false);
+    setCreated(null);
+    setError(null);
+  }
+
+  function onCreated(token: CreatedToken) {
+    setCreated(token);
+    setTokens((prev) => [
+      {
+        id: token.id,
+        name: token.name,
+        prefix: token.prefix,
+        createdAt: token.createdAt,
+        lastUsedAt: null,
+      },
+      ...prev,
+    ]);
+    startTransition(() => router.refresh());
+  }
+
+  async function revoke(id: string, name: string) {
+    if (revokingId) return;
+    if (!window.confirm(`Revoke "${name}"? This cannot be undone.`)) return;
+    setRevokingId(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/tokens/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        let message = `Revoke failed (${res.status})`;
+        try {
+          const data = await res.json();
+          if (data?.error) message = data.error;
+        } catch {}
+        setError(message);
+        return;
+      }
+      setTokens((prev) => prev.filter((t) => t.id !== id));
+      startTransition(() => router.refresh());
+    } catch {
+      setError("Network error");
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  return (
+    <>
+      {tokens.length === 0 ? (
+        <p className="settings__empty">
+          No tokens yet. Create one to start uploading via the API.
+        </p>
+      ) : (
+        <table className="token-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>ID</th>
+              <th>Last used</th>
+              <th aria-label="actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {tokens.map((t) => (
+              <tr key={t.id}>
+                <td className="token-table__name">{t.name}</td>
+                <td className="token-table__id">{t.prefix}…</td>
+                <td className="token-table__last-used">
+                  {relativeTime(t.lastUsedAt)}
+                </td>
+                <td className="token-table__actions">
+                  <button
+                    type="button"
+                    onClick={() => revoke(t.id, t.name)}
+                    disabled={revokingId === t.id}
+                    className="token-table__revoke"
+                  >
+                    {revokingId === t.id ? "revoking…" : "revoke"}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {error && (
+        <p className="settings__error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={() => {
+          setModalOpen(true);
+          setCreated(null);
+          setError(null);
+        }}
+        className="settings__create-btn"
+      >
+        Create new token
+      </button>
+
+      {modalOpen && (
+        <CreateTokenModal
+          onClose={closeModal}
+          onCreated={onCreated}
+          created={created}
+        />
+      )}
+    </>
+  );
+}
+
+function CreateTokenModal({
+  onClose,
+  onCreated,
+  created,
+}: {
+  onClose: () => void;
+  onCreated: (t: CreatedToken) => void;
+  created: CreatedToken | null;
+}) {
+  const [name, setName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!created) inputRef.current?.focus();
+  }, [created]);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Name is required");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/tokens", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: trimmed }),
+      });
+      if (!res.ok) {
+        let message = `Create failed (${res.status})`;
+        try {
+          const data = await res.json();
+          if (data?.error) message = data.error;
+        } catch {}
+        setError(message);
+        return;
+      }
+      const data = (await res.json()) as CreatedToken;
+      onCreated(data);
+    } catch {
+      setError("Network error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function copy() {
+    if (!created) return;
+    try {
+      await navigator.clipboard.writeText(created.plaintext);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard denied; user can select manually
+    }
+  }
+
+  return (
+    <div
+      className="modal-backdrop"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget && !created) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-token-title"
+        className="modal"
+      >
+        {!created ? (
+          <form onSubmit={submit} className="modal__form">
+            <h3 id="create-token-title" className="modal__title">
+              Create new token
+            </h3>
+            <p className="modal__desc">
+              Give the token a name so you can recognize it later (e.g.{" "}
+              <code>claude-laptop</code>, <code>browser-extension</code>).
+            </p>
+            <label className="modal__label">
+              <span>Name</span>
+              <input
+                ref={inputRef}
+                type="text"
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  if (error) setError(null);
+                }}
+                maxLength={64}
+                placeholder="claude-laptop"
+                className="modal__input"
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </label>
+            {error && (
+              <p className="modal__error" role="alert">
+                {error}
+              </p>
+            )}
+            <div className="modal__actions">
+              <button
+                type="button"
+                onClick={onClose}
+                className="modal__btn modal__btn--ghost"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !name.trim()}
+                className="modal__btn modal__btn--primary"
+              >
+                {submitting ? "Creating…" : "Create"}
+              </button>
+            </div>
+          </form>
+        ) : (
+          <div className="modal__form">
+            <h3 id="create-token-title" className="modal__title">
+              Token created
+            </h3>
+            <p className="modal__desc">
+              Copy the value below and store it somewhere safe. You won&apos;t
+              see it again — if you lose it, revoke and create a new one.
+            </p>
+            <div className="modal__token">
+              <code className="modal__token-value">{created.plaintext}</code>
+              <button
+                type="button"
+                onClick={copy}
+                className="modal__btn modal__btn--ghost"
+              >
+                {copied ? "copied" : "copy"}
+              </button>
+            </div>
+            <div className="modal__actions">
+              <button
+                type="button"
+                onClick={onClose}
+                className="modal__btn modal__btn--primary"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,54 @@
+import { redirect } from "next/navigation";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { isEmailAllowed } from "@/lib/access";
+import { listTokensForOwner } from "@/lib/api-tokens";
+import { Watermark } from "@/components/watermark";
+import { TokensSection } from "./_components/tokens-section";
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsPage() {
+  const { user } = await withAuth();
+
+  if (!user) {
+    redirect("/auth");
+  }
+
+  if (!isEmailAllowed(user.email)) {
+    redirect("/");
+  }
+
+  const tokens = await listTokensForOwner(user.id);
+
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
+      <div className="settings">
+        <div className="settings__watermark">
+          <Watermark variant="settings" />
+        </div>
+        <h1 className="settings__h1">Settings</h1>
+        <p className="settings__sub">
+          Preferences and API token management.
+        </p>
+
+        <section className="settings__section">
+          <h2 className="settings__section-h">API tokens</h2>
+          <p className="settings__section-intro">
+            Personal access tokens let scripts and AI agents call the API on your
+            behalf. Each token is shown only at creation; we store a hash, not
+            the value. Revoke a token to invalidate it immediately.
+          </p>
+          <TokensSection
+            initialTokens={tokens.map((t) => ({
+              id: t.id,
+              name: t.name,
+              prefix: t.prefix,
+              createdAt: t.createdAt.toISOString(),
+              lastUsedAt: t.lastUsedAt ? t.lastUsedAt.toISOString() : null,
+            }))}
+          />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/watermark.tsx
+++ b/src/components/watermark.tsx
@@ -247,7 +247,9 @@ function OperatorRows({
         <RowSoon icon={<CommandIcon />} kbd={["mod", "K"]}>
           command palette
         </RowSoon>
-        <RowSoon icon={<SettingsIcon />}>settings</RowSoon>
+        <RowLink href="/settings" icon={<SettingsIcon />}>
+          settings
+        </RowLink>
         <RowSoon icon={<ListIcon />}>all docs</RowSoon>
       </Group>
       {signOutAction && (

--- a/src/lib/api-tokens.test.ts
+++ b/src/lib/api-tokens.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { generateToken, hashToken } from "./api-tokens";
+
+describe("generateToken", () => {
+  it("prefixes plaintext with mdk_", () => {
+    const t = generateToken();
+    expect(t.plaintext.startsWith("mdk_")).toBe(true);
+  });
+
+  it("produces a token long enough to be unguessable (~256 bits of entropy)", () => {
+    const t = generateToken();
+    // mdk_ (4) + base64url(32 bytes) = 4 + 43 = 47 chars
+    expect(t.plaintext.length).toBe(47);
+  });
+
+  it("uses base64url alphabet for the random body", () => {
+    const t = generateToken();
+    const body = t.plaintext.slice("mdk_".length);
+    expect(body).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("yields a different value on every call", () => {
+    const a = generateToken();
+    const b = generateToken();
+    expect(a.plaintext).not.toBe(b.plaintext);
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  it("returns hash that matches hashToken(plaintext)", () => {
+    const t = generateToken();
+    expect(t.hash.length).toBeGreaterThan(0);
+    expect(t.hash).toBe(hashToken(t.plaintext));
+  });
+
+  it("returns prefix equal to first 8 chars of plaintext", () => {
+    const t = generateToken();
+    expect(t.prefix).toBe(t.plaintext.slice(0, 8));
+    expect(t.prefix.length).toBe(8);
+  });
+});
+
+describe("hashToken", () => {
+  it("is deterministic for the same input", () => {
+    const h = hashToken("mdk_abc");
+    expect(h.length).toBeGreaterThan(0);
+    expect(hashToken("mdk_abc")).toBe(h);
+  });
+
+  it("differs for different inputs", () => {
+    expect(hashToken("mdk_abc")).not.toBe(hashToken("mdk_xyz"));
+  });
+
+  it("returns a 64-char lowercase hex string (sha256 hex)", () => {
+    const h = hashToken("any-input-value");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("pins the sha256 hex of a known input — changing this would invalidate every existing token in the DB", () => {
+    expect(hashToken("mdk_test")).toBe(
+      "7b734232563402eeec9a4d637071044225ae4c9f3ed7ee5a956c5af37e81dc93",
+    );
+  });
+});

--- a/src/lib/api-tokens.ts
+++ b/src/lib/api-tokens.ts
@@ -1,0 +1,126 @@
+import { randomBytes, createHash } from "node:crypto";
+import { sql } from "@/lib/db";
+
+export type ApiTokenSummary = {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  revokedAt: Date | null;
+};
+
+export type CreatedApiToken = {
+  id: string;
+  name: string;
+  plaintext: string;
+  prefix: string;
+  createdAt: Date;
+};
+
+type ApiTokenRow = {
+  id: string;
+  owner_id: string;
+  name: string;
+  prefix: string;
+  created_at: Date;
+  last_used_at: Date | null;
+  revoked_at: Date | null;
+};
+
+const TOKEN_PREFIX = "mdk_";
+const TOKEN_RANDOM_BYTES = 32;
+const PREFIX_DISPLAY_LENGTH = 8;
+
+export type GeneratedToken = {
+  plaintext: string;
+  hash: string;
+  prefix: string;
+};
+
+export function generateToken(): GeneratedToken {
+  const body = randomBytes(TOKEN_RANDOM_BYTES).toString("base64url");
+  const plaintext = `${TOKEN_PREFIX}${body}`;
+  return {
+    plaintext,
+    hash: hashToken(plaintext),
+    prefix: plaintext.slice(0, PREFIX_DISPLAY_LENGTH),
+  };
+}
+
+export function hashToken(plaintext: string): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}
+
+function rowToSummary(row: ApiTokenRow): ApiTokenSummary {
+  return {
+    id: row.id,
+    name: row.name,
+    prefix: row.prefix,
+    createdAt: row.created_at,
+    lastUsedAt: row.last_used_at,
+    revokedAt: row.revoked_at,
+  };
+}
+
+export async function findActiveTokenByHash(
+  hash: string,
+): Promise<{ id: string; ownerId: string } | null> {
+  const result = await sql<{ id: string; owner_id: string }>`
+    SELECT id, owner_id
+    FROM api_tokens
+    WHERE token_hash = ${hash} AND revoked_at IS NULL
+    LIMIT 1
+  `;
+  const row = result.rows[0];
+  return row ? { id: row.id, ownerId: row.owner_id } : null;
+}
+
+export async function touchLastUsed(id: string): Promise<void> {
+  await sql`UPDATE api_tokens SET last_used_at = now() WHERE id = ${id}`;
+}
+
+export async function createApiToken(
+  ownerId: string,
+  name: string,
+): Promise<CreatedApiToken> {
+  const generated = generateToken();
+  const result = await sql<ApiTokenRow>`
+    INSERT INTO api_tokens (owner_id, name, token_hash, prefix)
+    VALUES (${ownerId}, ${name}, ${generated.hash}, ${generated.prefix})
+    RETURNING id, owner_id, name, prefix, created_at, last_used_at, revoked_at
+  `;
+  const row = result.rows[0];
+  if (!row) throw new Error("INSERT returned no rows");
+  return {
+    id: row.id,
+    name: row.name,
+    plaintext: generated.plaintext,
+    prefix: row.prefix,
+    createdAt: row.created_at,
+  };
+}
+
+export async function listTokensForOwner(
+  ownerId: string,
+): Promise<ApiTokenSummary[]> {
+  const result = await sql<ApiTokenRow>`
+    SELECT id, owner_id, name, prefix, created_at, last_used_at, revoked_at
+    FROM api_tokens
+    WHERE owner_id = ${ownerId} AND revoked_at IS NULL
+    ORDER BY created_at DESC
+  `;
+  return result.rows.map(rowToSummary);
+}
+
+export async function revokeToken(
+  ownerId: string,
+  id: string,
+): Promise<boolean> {
+  const result = await sql`
+    UPDATE api_tokens
+    SET revoked_at = now()
+    WHERE id = ${id} AND owner_id = ${ownerId} AND revoked_at IS NULL
+  `;
+  return (result.rowCount ?? 0) > 0;
+}

--- a/src/lib/api-tokens.ts
+++ b/src/lib/api-tokens.ts
@@ -77,7 +77,11 @@ export async function findActiveTokenByHash(
 }
 
 export async function touchLastUsed(id: string): Promise<void> {
-  await sql`UPDATE api_tokens SET last_used_at = now() WHERE id = ${id}`;
+  await sql`
+    UPDATE api_tokens
+    SET last_used_at = now()
+    WHERE id = ${id} AND revoked_at IS NULL
+  `;
 }
 
 export async function createApiToken(

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findActiveTokenByHash: vi.fn(),
+  touchLastUsed: vi.fn(),
+  hashToken: vi.fn((s: string) => `hash:${s}`),
+  withAuth: vi.fn(),
+  isEmailAllowed: vi.fn(),
+}));
+
+vi.mock("@/lib/api-tokens", () => ({
+  findActiveTokenByHash: mocks.findActiveTokenByHash,
+  touchLastUsed: mocks.touchLastUsed,
+  hashToken: mocks.hashToken,
+}));
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: mocks.withAuth,
+}));
+
+vi.mock("@/lib/access", () => ({
+  isEmailAllowed: mocks.isEmailAllowed,
+}));
+
+import { requireAuth, requireSessionAuth } from "./auth";
+
+function reqWith(headers: Record<string, string>): Request {
+  return {
+    headers: {
+      get: (key: string) => headers[key.toLowerCase()] ?? null,
+    },
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  mocks.findActiveTokenByHash.mockReset();
+  mocks.touchLastUsed.mockReset();
+  mocks.hashToken.mockClear();
+  mocks.hashToken.mockImplementation((s: string) => `hash:${s}`);
+  mocks.withAuth.mockReset();
+  mocks.isEmailAllowed.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("requireAuth — bearer path", () => {
+  it("authenticates with a valid token, returns owner from DB row, and updates last_used_at", async () => {
+    mocks.findActiveTokenByHash.mockResolvedValueOnce({
+      id: "tok-1",
+      ownerId: "user-42",
+    });
+    mocks.touchLastUsed.mockResolvedValueOnce(undefined);
+
+    const result = await requireAuth(
+      reqWith({ authorization: "Bearer mdk_secret" }),
+    );
+
+    expect(result).toEqual({
+      authenticated: true,
+      ownerId: "user-42",
+      via: "bearer",
+    });
+    expect(mocks.hashToken).toHaveBeenCalledWith("mdk_secret");
+    expect(mocks.touchLastUsed).toHaveBeenCalledWith("tok-1");
+  });
+
+  it("does not block the request if touchLastUsed throws", async () => {
+    mocks.findActiveTokenByHash.mockResolvedValueOnce({
+      id: "tok-1",
+      ownerId: "user-42",
+    });
+    mocks.touchLastUsed.mockRejectedValueOnce(new Error("DB blip"));
+
+    const result = await requireAuth(
+      reqWith({ authorization: "Bearer mdk_secret" }),
+    );
+    expect(result.authenticated).toBe(true);
+  });
+
+  it("returns 401 when the bearer token is unknown to the DB", async () => {
+    mocks.findActiveTokenByHash.mockResolvedValueOnce(null);
+
+    const result = await requireAuth(
+      reqWith({ authorization: "Bearer mdk_unknown" }),
+    );
+
+    expect(result).toEqual({
+      authenticated: false,
+      status: 401,
+      reason: "Invalid API key",
+    });
+    expect(mocks.touchLastUsed).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 'Empty bearer token' when the header has no value after Bearer", async () => {
+    const result = await requireAuth(reqWith({ authorization: "Bearer " }));
+    expect(result).toEqual({
+      authenticated: false,
+      status: 401,
+      reason: "Empty bearer token",
+    });
+    expect(mocks.findActiveTokenByHash).not.toHaveBeenCalled();
+  });
+});
+
+describe("requireAuth — session path", () => {
+  it("authenticates an allow-listed signed-in user", async () => {
+    mocks.withAuth.mockResolvedValueOnce({
+      user: { id: "u-1", email: "ok@ex.com" },
+    });
+    mocks.isEmailAllowed.mockReturnValueOnce(true);
+
+    const result = await requireAuth(reqWith({}));
+    expect(result).toEqual({
+      authenticated: true,
+      ownerId: "u-1",
+      via: "session",
+    });
+  });
+
+  it("returns 401 'Not signed in' when there is no user", async () => {
+    mocks.withAuth.mockResolvedValueOnce({ user: null });
+
+    const result = await requireAuth(reqWith({}));
+    expect(result).toEqual({
+      authenticated: false,
+      status: 401,
+      reason: "Not signed in",
+    });
+  });
+
+  it("returns 403 when the user's email is not on the allow list", async () => {
+    mocks.withAuth.mockResolvedValueOnce({
+      user: { id: "u-1", email: "blocked@ex.com" },
+    });
+    mocks.isEmailAllowed.mockReturnValueOnce(false);
+
+    const result = await requireAuth(reqWith({}));
+    expect(result).toEqual({
+      authenticated: false,
+      status: 403,
+      reason: "Email not on allow list",
+    });
+  });
+});
+
+describe("requireSessionAuth", () => {
+  it("rejects any request with a Bearer header — token-management is session-only", async () => {
+    mocks.findActiveTokenByHash.mockResolvedValue({
+      id: "tok-1",
+      ownerId: "user-42",
+    });
+
+    const result = await requireSessionAuth(
+      reqWith({ authorization: "Bearer mdk_real_token" }),
+    );
+
+    expect(result).toEqual({
+      authenticated: false,
+      status: 401,
+      reason: "Session required for token management",
+    });
+    expect(mocks.findActiveTokenByHash).not.toHaveBeenCalled();
+    expect(mocks.withAuth).not.toHaveBeenCalled();
+  });
+
+  it("authenticates an allow-listed signed-in user with email", async () => {
+    mocks.withAuth.mockResolvedValueOnce({
+      user: { id: "u-1", email: "ok@ex.com" },
+    });
+    mocks.isEmailAllowed.mockReturnValueOnce(true);
+
+    const result = await requireSessionAuth(reqWith({}));
+    expect(result).toEqual({
+      authenticated: true,
+      ownerId: "u-1",
+      email: "ok@ex.com",
+    });
+  });
+
+  it("returns 401 when no user", async () => {
+    mocks.withAuth.mockResolvedValueOnce({ user: null });
+
+    const result = await requireSessionAuth(reqWith({}));
+    expect(result).toEqual({
+      authenticated: false,
+      status: 401,
+      reason: "Not signed in",
+    });
+  });
+
+  it("returns 403 when email is not allow-listed", async () => {
+    mocks.withAuth.mockResolvedValueOnce({
+      user: { id: "u-1", email: "blocked@ex.com" },
+    });
+    mocks.isEmailAllowed.mockReturnValueOnce(false);
+
+    const result = await requireSessionAuth(reqWith({}));
+    expect(result).toEqual({
+      authenticated: false,
+      status: 403,
+      reason: "Email not on allow list",
+    });
+  });
+});

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -166,6 +166,24 @@ describe("requireSessionAuth", () => {
     expect(mocks.withAuth).not.toHaveBeenCalled();
   });
 
+  it.each([
+    "bearer mdk_lowercase",
+    "ApiKey foo",
+    "HMAC abc123",
+    "  Bearer with-leading-whitespace  ",
+  ])(
+    "rejects non-Bearer / oddly-cased Authorization headers (%s)",
+    async (header) => {
+      const result = await requireSessionAuth(reqWith({ authorization: header }));
+      expect(result).toEqual({
+        authenticated: false,
+        status: 401,
+        reason: "Session required for token management",
+      });
+      expect(mocks.withAuth).not.toHaveBeenCalled();
+    },
+  );
+
   it("authenticates an allow-listed signed-in user with email", async () => {
     mocks.withAuth.mockResolvedValueOnce({
       user: { id: "u-1", email: "ok@ex.com" },

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -103,6 +103,20 @@ describe("requireAuth — bearer path", () => {
     });
     expect(mocks.findActiveTokenByHash).not.toHaveBeenCalled();
   });
+
+  it.each(["Bearer mdk_x", "bearer mdk_x", "BEARER mdk_x", "bEaReR mdk_x"])(
+    "accepts case-insensitive Bearer scheme per RFC 7235 (%s)",
+    async (header) => {
+      mocks.findActiveTokenByHash.mockResolvedValueOnce({
+        id: "tok-1",
+        ownerId: "user-42",
+      });
+      mocks.touchLastUsed.mockResolvedValueOnce(undefined);
+      const result = await requireAuth(reqWith({ authorization: header }));
+      expect(result.authenticated).toBe(true);
+      expect(mocks.hashToken).toHaveBeenCalledWith("mdk_x");
+    },
+  );
 });
 
 describe("requireAuth — session path", () => {

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -35,6 +35,10 @@ function reqWith(headers: Record<string, string>): Request {
 beforeEach(() => {
   mocks.findActiveTokenByHash.mockReset();
   mocks.touchLastUsed.mockReset();
+  // Real `touchLastUsed` returns Promise<void>; default the mock so tests don't
+  // have to set this per-call. `requireAuth` calls `.catch()` on the return
+  // value, which would otherwise throw when the mock returns undefined.
+  mocks.touchLastUsed.mockResolvedValue(undefined);
   mocks.hashToken.mockClear();
   mocks.hashToken.mockImplementation((s: string) => `hash:${s}`);
   mocks.withAuth.mockReset();
@@ -51,7 +55,6 @@ describe("requireAuth — bearer path", () => {
       id: "tok-1",
       ownerId: "user-42",
     });
-    mocks.touchLastUsed.mockResolvedValueOnce(undefined);
 
     const result = await requireAuth(
       reqWith({ authorization: "Bearer mdk_secret" }),
@@ -111,7 +114,6 @@ describe("requireAuth — bearer path", () => {
         id: "tok-1",
         ownerId: "user-42",
       });
-      mocks.touchLastUsed.mockResolvedValueOnce(undefined);
       const result = await requireAuth(reqWith({ authorization: header }));
       expect(result.authenticated).toBe(true);
       expect(mocks.hashToken).toHaveBeenCalledWith("mdk_x");

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -27,7 +27,9 @@ export async function requireAuth(req: Request): Promise<AuthResult> {
     if (!match) {
       return { authenticated: false, status: 401, reason: "Invalid API key" };
     }
-    void touchLastUsed(match.id).catch(() => {});
+    void touchLastUsed(match.id).catch((err) => {
+      console.warn("[auth] failed to update last_used_at", err);
+    });
     return { authenticated: true, ownerId: match.ownerId, via: "bearer" };
   }
 
@@ -37,7 +39,10 @@ export async function requireAuth(req: Request): Promise<AuthResult> {
 export async function requireSessionAuth(
   req: Request,
 ): Promise<SessionAuthResult> {
-  if (req.headers.get("authorization")?.startsWith("Bearer ")) {
+  // Reject any Authorization header — token-management is session-only by design.
+  // Stricter than `startsWith("Bearer ")` so future auth schemes (HMAC, ApiKey, etc.)
+  // can't silently bypass this check, and so case variants like `bearer foo` are caught.
+  if ((req.headers.get("authorization") ?? "").trim().length > 0) {
     return {
       authenticated: false,
       status: 401,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,48 +1,74 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
+import {
+  findActiveTokenByHash,
+  hashToken,
+  touchLastUsed,
+} from "@/lib/api-tokens";
 
 export type AuthResult =
   | { authenticated: true; ownerId: string; via: "bearer" | "session" }
   | { authenticated: false; status: 401 | 403; reason: string };
 
-// Trim env values to defend against accidental trailing whitespace (e.g. from
-// `echo "..." | vercel env add`, which pipes a trailing newline into the value).
-const API_KEY = (process.env.MD_API_KEY ?? "").trim();
-const API_OWNER_ID = (process.env.MD_API_OWNER_ID ?? "").trim();
-
-function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let mismatch = 0;
-  for (let i = 0; i < a.length; i++) {
-    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return mismatch === 0;
-}
+export type SessionAuthResult =
+  | { authenticated: true; ownerId: string; email: string }
+  | { authenticated: false; status: 401 | 403; reason: string };
 
 export async function requireAuth(req: Request): Promise<AuthResult> {
   const authHeader = req.headers.get("authorization");
 
   if (authHeader?.startsWith("Bearer ")) {
     const token = authHeader.slice("Bearer ".length).trim();
-    if (!API_KEY || !API_OWNER_ID) {
-      return {
-        authenticated: false,
-        status: 401,
-        reason: "API authentication not configured on server",
-      };
+    if (!token) {
+      return { authenticated: false, status: 401, reason: "Empty bearer token" };
     }
-    if (!timingSafeEqual(token, API_KEY)) {
+
+    const match = await findActiveTokenByHash(hashToken(token));
+    if (!match) {
       return { authenticated: false, status: 401, reason: "Invalid API key" };
     }
-    return { authenticated: true, ownerId: API_OWNER_ID, via: "bearer" };
+    void touchLastUsed(match.id).catch(() => {});
+    return { authenticated: true, ownerId: match.ownerId, via: "bearer" };
   }
 
+  return await resolveSession();
+}
+
+export async function requireSessionAuth(
+  req: Request,
+): Promise<SessionAuthResult> {
+  if (req.headers.get("authorization")?.startsWith("Bearer ")) {
+    return {
+      authenticated: false,
+      status: 401,
+      reason: "Session required for token management",
+    };
+  }
   const { user } = await withAuth();
   if (!user) {
     return { authenticated: false, status: 401, reason: "Not signed in" };
   }
   if (!isEmailAllowed(user.email)) {
-    return { authenticated: false, status: 403, reason: "Email not on allow list" };
+    return {
+      authenticated: false,
+      status: 403,
+      reason: "Email not on allow list",
+    };
+  }
+  return { authenticated: true, ownerId: user.id, email: user.email };
+}
+
+async function resolveSession(): Promise<AuthResult> {
+  const { user } = await withAuth();
+  if (!user) {
+    return { authenticated: false, status: 401, reason: "Not signed in" };
+  }
+  if (!isEmailAllowed(user.email)) {
+    return {
+      authenticated: false,
+      status: 403,
+      reason: "Email not on allow list",
+    };
   }
   return { authenticated: true, ownerId: user.id, via: "session" };
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -14,11 +14,17 @@ export type SessionAuthResult =
   | { authenticated: true; ownerId: string; email: string }
   | { authenticated: false; status: 401 | 403; reason: string };
 
+// RFC 7235 §2.1 — auth-scheme tokens are case-insensitive. The captured group
+// may be empty (e.g. "Bearer " with trailing whitespace and no token), in
+// which case the empty-bearer branch below fires.
+const BEARER_RE = /^Bearer(?:\s+(.*))?$/i;
+
 export async function requireAuth(req: Request): Promise<AuthResult> {
   const authHeader = req.headers.get("authorization");
+  const bearerMatch = authHeader?.match(BEARER_RE);
 
-  if (authHeader?.startsWith("Bearer ")) {
-    const token = authHeader.slice("Bearer ".length).trim();
+  if (bearerMatch) {
+    const token = (bearerMatch[1] ?? "").trim();
     if (!token) {
       return { authenticated: false, status: 401, reason: "Empty bearer token" };
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,8 +7,11 @@ export const config = {
     "/",
     "/v/:slug*",
     "/edit/:slug*",
+    "/settings",
     "/api/upload",
     "/api/docs/:slug*",
     "/api/list",
+    "/api/tokens",
+    "/api/tokens/:id*",
   ],
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    globals: false,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Replaces the single shared `MD_API_KEY` env-var with hashed personal API tokens stored in Postgres, addressing #14. Each token is generated as `mdk_<base64url(32 bytes)>`, sha256-hashed at rest, owner-scoped to the WorkOS user, and revocable from a new `/settings` page.

The legacy `MD_API_KEY` / `MD_API_OWNER_ID` env-var auth path is removed in this same PR (no transitional dual-auth) — see issue thread for the rationale around the shared-DB / single-operator setup that made the two-PR landing unnecessary.

## What changed

- New `api_tokens` table: `id, owner_id, name, token_hash, prefix, created_at, last_used_at, revoked_at`. Partial index on active rows.
- `src/lib/api-tokens.ts`: token data layer (generate, hash, find-by-hash, touch-last-used, create, list, revoke).
- `src/lib/auth.ts`: `requireAuth` does sha256 DB lookup on bearer; new `requireSessionAuth` is session-only and rejects any non-empty `Authorization` header (defense against future auth-scheme drift and against token-spawn-from-leaked-token escalation).
- Token CRUD endpoints under `/api/tokens` (session-only auth).
- `/settings` page with the API tokens section per `docs/design-vision.html`. Reading / Defaults / Account sections deferred to #24.
- Watermark `settings` row on the operator menu is now a real link (was inert).
- `next/script` `beforeInteractive` replaces the inline pre-hydration `<script>` to silence a React 19 dev warning without resorting to `suppressHydrationWarning`.
- `md-upload` skill, `.env.example`, `README.md`, `CLAUDE.md`, `docs/test-scenarios.md` updated to point at `/settings` for token creation.
- 25 vitest tests across `api-tokens.ts` and `auth.ts` (TDD: stubs first, every test red, then real impl turned them green).

## Security audit

A read-only audit found 0 critical, 0 high, 2 medium (both addressed in the second commit on this branch), 5 low (4 deferred to follow-up issues), 5 info (deferred). Verified safe: token entropy, sha256 vs KDF choice for high-entropy tokens, owner scoping, CSRF posture (SameSite=Lax + JSON content-type forces preflight), SQL parameterization, route privacy, proxy matcher coverage, mass assignment, cache headers on auth'd responses, Next.js private-folder underscore convention.

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings page for managing personal API tokens: create, monitor usage with last-accessed timestamps, and revoke tokens
  * Bearer token authentication for API requests

* **Documentation**
  * Updated API reference and configuration guide for token-based authentication

* **Tests**
  * Added Vitest testing framework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->