### PR TITLE
feat(settings): add Reading + Account sections with server-rendered prefs

### DIFF
--- a/docs/cmd-palette-and-discoverability.md
+++ b/docs/cmd-palette-and-discoverability.md
@@ -1,0 +1,119 @@
+# Cmd palette + hotkey discoverability — design doc
+
+This doc captures the rationale and target shape for refining the cmd palette and introducing a dedicated hotkey cheat-sheet. Implementation is tracked separately as a GitHub issue; this file is the load-bearing reference for whoever picks the work up.
+
+## Context
+
+PR #36 (merged 2026-05-02) made the cmd palette the operator's primary verb-tool. After living with it, three rough edges surfaced:
+
+1. **The documents section feels unbounded.** Idle state shows up to 8 docs with no label explaining what they are (recent? all? filtered?). The bounds aren't obvious.
+2. **The actions section mixes incompatible kinds of items.** Some are global verbs only reachable via the palette (Open settings, Sign out). Others are redundant with toolbar buttons or hotkeys (Back to dashboard, Copy link, View raw). Some are contextual "this document" verbs (Edit this, View this) that better belong on the surface they act on.
+3. **There's no consistent place to learn what hotkeys exist.** Today the palette doubles as a hotkey advertisement board (`g d`, `g n` chips on palette rows), but that role conflicts with the palette's other jobs and doesn't scale as the hotkey count grows.
+
+The Linear / Raycast reference lane (called out in PRODUCT.md) treats these as three different jobs: jumping (palette), browsing (filter bar), and hotkey learning (cheat-sheet). Today we conflate them.
+
+## Principles
+
+1. **Each tool has one job.** Palette = navigate to a thing or run a global verb. Filter bar = refine a list in place. Cheat-sheet = learn what hotkeys exist. No tool should drift into another's job.
+2. **Each hotkey has exactly one discovery surface.** Either the toolbar tooltip (when a button already exists for click reasons) or the cheat-sheet. The palette is not a hotkey advertisement board.
+3. **Editorial test for palette inclusion.** A candidate row earns a slot iff it is *the only path* to the action, *or* it is the find-by-name surface for an entity (today: documents). Discovery alone does not earn a slot — that's the cheat-sheet's job.
+4. **Toolbar buttons earn their place by being click affordances.** Never add a button purely to advertise a hotkey. The tooltip-hotkey is a side benefit of a button that's already justified for clicking.
+
+## Tool roles, sharply
+
+| Tool | Job | Shape |
+|---|---|---|
+| **Toolbar** | Contextual click affordances on the surface they belong to. Tooltips advertise hotkeys for free. | Per-surface (reader, editor, settings, dashboard). |
+| **Filter bar** *(dashboard only)* | Refine the doc list in place. Text + tags + sort. URL-stateful. | Owned by #25 (tags + dashboard filter chips). This issue does not duplicate it. |
+| **Cmd palette** | Find a doc by name from anywhere; run a global verb that has no faster path. | Two sections: docs (Recent / Documents) + Actions. Same on every page. |
+| **`?` cheat-sheet** | Single source of truth for every hotkey, grouped by surface. | Overlay triggered by `?` (Shift+/). Esc dismisses. |
+
+## Cmd palette — current vs proposed
+
+### Current (post-#36)
+
+| Section | Idle | On query |
+|---|---|---|
+| Documents | up to 8 most-recent (no label) | up to 8 search hits (no label) |
+| Actions | up to 8 contextual (Back to dashboard, New, Edit this, View this, Copy link, View raw, Open settings, Sign out) | filtered |
+
+### Proposed
+
+| Section | Idle | On query |
+|---|---|---|
+| `Recent` / `Documents` | 3 most-recent docs under the label `Recent` | up to 8 search hits under the label `Documents` |
+| `Actions` | `Open settings`, `Sign out` | filtered |
+
+Net: idle palette shows ~5 rows on every page, every entry is load-bearing, the docs section has a clear identity that changes with intent.
+
+### What gets dropped from the palette and why
+
+| Action | Why it leaves |
+|---|---|
+| Back to dashboard | `g d` hotkey + reader toolbar button + settings "← dashboard" link already cover it. Triple redundant. |
+| New document | `g n` hotkey + dashboard primary button cover it. Double redundant. |
+| Edit this document | Becomes a toolbar button on the reader (see below). |
+| View this document | Becomes a toolbar button on the editor (see below). |
+| Copy link | Reader toolbar button + `c` hotkey already cover it. |
+| View raw markdown | Reader toolbar button + `r` hotkey already cover it. |
+
+The hotkeys themselves (`g d`, `g n`, `c`, `r`) don't disappear — they migrate their discovery surface to the cheat-sheet (and tooltips, where the button already exists).
+
+## Toolbar additions
+
+- **Reader (`/v/[slug]`).** Add an "Edit document" button to the existing vertical toolbar cluster (alongside outline-toggle, R/W pill, copy-link, view-raw, dashboard). Visible only when the viewer is the authed operator. Tooltip: "Edit (e)".
+- **Editor (`/edit/[slug]`).** Add a "View document" button to the editor's bottom button cluster (alongside Cancel and Save). Tooltip: "View".
+
+After these additions, the cleanest contextual verbs for "this document" live on the surface where "this document" actually means something.
+
+## `?` cheat-sheet
+
+A modal overlay triggered by `?` (Shift+/) globally. Lists every hotkey grouped by surface:
+
+- **Global** — `⌘K` palette, `g d` dashboard, `g n` /new, `?` this overlay
+- **Reader** — `r` raw, `c` copy link, `o` toggle outline, `w` toggle width, `e` edit
+- **Editor** — `⌘S` save, `Esc` cancel
+- **Settings** — `Esc` back
+
+Dismissed by Esc. Same trigger and dismiss model as the palette so the muscle memory is consistent. No discoverability surface for `?` itself beyond convention — this matches Linear, GitHub, Notion, Raycast.
+
+## The discoverability pattern, codified
+
+> A hotkey needs **exactly one** discovery surface. The toolbar is a discovery surface only as a side effect of being a click affordance — never add a button purely to advertise a hotkey. If a hotkey has no button (because the button isn't justified on its own merits), its discovery surface is the `?` cheat-sheet.
+
+Concretely, after this change:
+
+| Hotkey | Discovery surface |
+|---|---|
+| `⌘K` | Cheat-sheet + the dashboard's "press ⌘K to navigate" hint |
+| `g d` | Cheat-sheet |
+| `g n` | Cheat-sheet |
+| `?` | Convention (no surface) |
+| Reader `r` | Toolbar tooltip ("View raw (r)") + cheat-sheet |
+| Reader `c` | Toolbar tooltip ("Copy link (c)") + cheat-sheet |
+| Reader `o` | Toolbar tooltip ("Toggle outline (o)") + cheat-sheet |
+| Reader `w` | Toolbar tooltip ("Toggle width (w)") + cheat-sheet |
+| Reader `e` | Toolbar tooltip ("Edit (e)") + cheat-sheet |
+| Editor `⌘S` | Save button kbd hint + cheat-sheet |
+| Editor `Esc` | Cancel button kbd hint + cheat-sheet |
+
+Every hotkey is reachable via the cheat-sheet; toolbar tooltips are the faster discovery path when the user already has hand-on-mouse.
+
+## Relationship to other issues
+
+- **#25 — Add tagging system (multi-label tags + edit chip-input + dashboard filters).** The dashboard filter bar is part of #25. The work in *this* issue does not duplicate that scope. When #25 ships, the filter bar gains tags as one of its dimensions; the principle that the filter bar lives on the dashboard (not in the palette) is settled here.
+- **#36 — cmd palette + nav redesign (merged).** This issue is the follow-up that addresses what we learned by living with the post-#36 shape.
+
+## Out of scope
+
+- Dashboard filter bar (text + sort + tags). Owned by #25; expanding #25 to cover non-tag dimensions of the filter bar is a coordination call.
+- Fuzzy match in the palette. Today's substring filter is fine for ~5 actions + ≤8 docs. Revisit only if the palette grows past ~12 rows.
+- Dashboard's existing "press ⌘K to navigate" hint stays as-is.
+- Per-doc indexing (#12), per-doc kind UI (deferred indefinitely per the conversation in PR #37).
+
+## Open questions resolved during the design conversation
+
+- **Should documents be page-scoped (e.g. hidden on dashboard)?** No. The palette is the only text-search surface in the entire app; hiding it anywhere strands docs that scrolled off the visible list. Docs section is identical on every surface.
+- **Does every hotkey need a toolbar button?** No. Buttons exist for click reasons; tooltips advertise hotkeys as a side benefit. Hotkeys without buttons get their discovery from the cheat-sheet.
+- **`?` cheat-sheet trigger — `?` only or also a discoverable element?** `?` only. Adding a `?` icon somewhere would be UX cliché and add chrome the system doesn't need. Convention covers it.
+- **Should "Sign out" stay in the palette now that the settings page has it?** Yes. Sign-out is an infrequent terminal action that's useful from anywhere; navigating to settings to reach it is friction.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Vendored Claude Code skills ship minified UMD bundles and dev scripts
+    // that aren't part of the app surface; lint shouldn't gate on them.
+    ".claude/**",
   ]),
 ]);
 

--- a/migrations/004_create_user_preferences_table.sql
+++ b/migrations/004_create_user_preferences_table.sql
@@ -1,0 +1,18 @@
+-- 004_create_user_preferences_table.sql
+-- Per-user preferences (issue #24). Drives Reading section behavior on
+-- /settings, and is read server-side by app/layout.tsx so the first paint
+-- reflects the user's chosen width and outline auto-show state without a
+-- localStorage round-trip. owner_id is the WorkOS user.id (text), matching
+-- docs.owner_id and api_tokens.owner_id.
+--
+-- The default_kind column shipped here is dropped in migration 005; see
+-- that file for context. It remains in this file's history so applied
+-- migrations are never mutated retroactively.
+
+CREATE TABLE user_preferences (
+  owner_id text PRIMARY KEY,
+  auto_show_outline boolean NOT NULL DEFAULT true,
+  default_width text NOT NULL DEFAULT 'reading',
+  default_kind text,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/migrations/005_drop_default_kind_column.sql
+++ b/migrations/005_drop_default_kind_column.sql
@@ -1,0 +1,11 @@
+-- 005_drop_default_kind_column.sql
+-- Drops the user_preferences.default_kind column added in migration 004.
+-- The Defaults UI section was cut from issue #24 before merge: with the
+-- broader kind/tag direction still under design, exposing a default-kind
+-- input would entrench `kind` in the UI just as we were considering
+-- replacing it with tags. The column had no UI surface and no API surface,
+-- so removal is loss-free. Future-proof preference storage stays via the
+-- table itself, and subsequent migrations re-add columns as real defaults
+-- ship.
+
+ALTER TABLE user_preferences DROP COLUMN IF EXISTS default_kind;

--- a/migrations/006_constrain_default_width.sql
+++ b/migrations/006_constrain_default_width.sql
@@ -1,0 +1,12 @@
+-- 006_constrain_default_width.sql
+-- Adds a CHECK constraint so user_preferences.default_width can only hold the
+-- values the application actually accepts. validatePartialPreferences in
+-- src/lib/user-preferences.ts already validates at the API boundary, and
+-- mergeWithDefaults silently coerces unknown values back to 'reading' on read,
+-- but a direct DB write (manual fix-up, future migration, anything bypassing
+-- validation) could otherwise persist a bad value. Defense-in-depth at the
+-- column boundary keeps the schema honest.
+
+ALTER TABLE user_preferences
+  ADD CONSTRAINT user_preferences_default_width_check
+  CHECK (default_width IN ('reading', 'wide'));

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,6 +24,27 @@
   display: none;
 }
 
+/* Width pill — keyed on :root[data-width] so the visible active button is
+   correct from first paint (the pre-hydration script writes data-width
+   synchronously). aria-pressed remains on the button for accessibility. */
+:root:not([data-width="wide"]) [data-width-pill="reading"],
+:root[data-width="wide"] [data-width-pill="wide"] {
+  background: var(--ochre);
+  color: var(--paper);
+  font-weight: 600;
+}
+
+/* Outline toggle button — same pattern. Active when the outline is shown
+   (i.e. :root has no data-outline-hidden). */
+:root:not([data-outline-hidden]) [data-outline-toggle] {
+  border-color: var(--ochre);
+  background: var(--ochre);
+  color: var(--paper);
+}
+:root:not([data-outline-hidden]) [data-outline-toggle]:hover {
+  color: var(--paper);
+}
+
 /* Outline rail's internal scrollbar — invisible at rest; appears tinted (not
    the bright browser default) while the page is scrolling or while hovered. */
 [data-outline-scroll] {
@@ -290,6 +311,29 @@ button.cmd-palette-row:hover:not([data-selected="true"]) {
   margin-bottom: 32px;
 }
 
+.settings__back-nav {
+  position: absolute;
+  top: 32px;
+  right: clamp(28px, 5vw, 56px);
+  display: flex;
+  justify-content: flex-end;
+}
+.settings__back-link {
+  color: var(--muted);
+  border: 1px solid var(--border);
+  padding: 4px 10px;
+  border-radius: 4px;
+  text-decoration: none;
+  font-size: 0.75rem;
+  font-weight: 500;
+  transition: color 150ms, border-color 150ms, background-color 150ms;
+}
+.settings__back-link:hover {
+  color: var(--ochre-deep);
+  border-color: var(--ochre);
+  background: var(--paper);
+}
+
 .settings__section + .settings__section {
   margin-top: 32px;
 }
@@ -342,6 +386,136 @@ button.cmd-palette-row:hover:not([data-selected="true"]) {
   color: var(--ochre-deep);
 }
 
+.settings__row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border);
+}
+.settings__row:last-of-type {
+  border-bottom: 0;
+}
+.settings__row-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.settings__row-title {
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--ink);
+}
+.settings__row-help {
+  font-size: 0.8125rem;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.settings__toggle {
+  position: relative;
+  flex-shrink: 0;
+  width: 36px;
+  height: 20px;
+  border-radius: 999px;
+  border: 0;
+  background: color-mix(in oklch, var(--ink) 22%, transparent);
+  cursor: pointer;
+  transition: background-color 180ms;
+}
+.settings__toggle[data-on="true"] {
+  background: var(--ochre);
+}
+.settings__toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--paper);
+  box-shadow: 0 1px 3px oklch(0% 0 0 / 0.25);
+  transition: transform 180ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+.settings__toggle[data-on="true"] .settings__toggle-thumb {
+  transform: translateX(16px);
+}
+
+.settings__pill {
+  display: inline-flex;
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--paper);
+}
+.settings__pill button {
+  padding: 6px 14px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 150ms, color 150ms;
+}
+.settings__pill button + button {
+  border-left: 1px solid var(--border);
+}
+.settings__pill button[data-active="true"] {
+  background: var(--ochre);
+  color: var(--paper);
+}
+.settings__pill button:hover:not([data-active="true"]) {
+  color: var(--ink);
+  background: var(--paper-warm);
+}
+
+.settings__input {
+  flex-shrink: 0;
+  width: 220px;
+  background: var(--paper-warm);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.875rem;
+  color: var(--ink);
+  outline: none;
+  transition: border-color 150ms;
+}
+.settings__input:focus {
+  border-color: var(--ochre);
+}
+
+.settings__hint {
+  margin-top: 12px;
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.settings__sign-out {
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  background: var(--paper);
+  color: var(--ink);
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 200ms, color 200ms;
+}
+.settings__sign-out:hover {
+  border-color: var(--ochre);
+  color: var(--ochre-deep);
+}
+
 .token-table {
   width: 100%;
   border-collapse: collapse;
@@ -354,16 +528,21 @@ button.cmd-palette-row:hover:not([data-selected="true"]) {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--muted);
-  padding: 0 0 8px;
+  padding: 0 32px 8px 0;
   border-bottom: 1px solid var(--border);
+  white-space: nowrap;
 }
 .token-table thead th:last-child {
-  width: 1%;
+  padding-right: 0;
+}
+.token-table thead th {
+  width: 25%;
 }
 .token-table tbody td {
-  padding: 12px 0;
+  padding: 12px 32px 12px 0;
   border-bottom: 1px solid var(--border);
   vertical-align: middle;
+  width: 25%;
 }
 .token-table tbody tr:last-child td {
   border-bottom: 0;
@@ -371,26 +550,21 @@ button.cmd-palette-row:hover:not([data-selected="true"]) {
 .token-table__name {
   font-weight: 500;
   color: var(--ink);
-  padding-right: 24px;
-  width: auto;
 }
 .token-table__id {
   font-family: var(--font-mono), ui-monospace, monospace;
   font-size: 0.8125rem;
   color: var(--muted);
-  padding-right: 24px;
   white-space: nowrap;
-  width: 1%;
 }
 .token-table__last-used {
   color: var(--muted);
-  padding-right: 16px;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
-  width: 1%;
 }
 .token-table__actions {
   text-align: right;
+  padding-right: 0;
 }
 .token-table__revoke {
   background: transparent;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,20 +2,17 @@ import type { Metadata } from "next";
 import Script from "next/script";
 import { Inter_Tight, Geist_Mono } from "next/font/google";
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
-import { withAuth, signOut } from "@workos-inc/authkit-nextjs";
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
+import { signOutAction } from "@/lib/auth-actions";
+import { getUserPreferences } from "@/lib/user-preferences";
+import { prefsToHtmlAttrs } from "@/lib/prefs-html-attrs";
+import { buildPreHydrationScript } from "@/lib/pre-hydration-script";
 import { DevThemeSwitcher } from "@/components/dev-theme-switcher";
 import { CmdPalette } from "@/components/cmd-palette";
 import { BrandMark } from "@/components/brand-mark";
 import { DropAnywhere } from "@/components/drop-anywhere";
 import "./globals.css";
-
-async function signOutAction() {
-  "use server";
-  await signOut();
-}
-
-const PRE_HYDRATION_SCRIPT = `(function(){try{var w=localStorage.getItem('md.width');if(w==='wide')document.documentElement.setAttribute('data-width','wide');var o=localStorage.getItem('md.outline.shown');if(o==='false')document.documentElement.setAttribute('data-outline-hidden','1');var t=localStorage.getItem('md.dev-theme');if(t==='light'||t==='dark'){document.documentElement.setAttribute('data-theme',t);document.documentElement.setAttribute('data-dev-theme',t);}var ua=navigator.userAgent||'';var p=(navigator.userAgentData&&navigator.userAgentData.platform)||'';if(/Mac|iPhone|iPad/.test(ua)||/macOS|iOS/.test(p))document.documentElement.setAttribute('data-platform','mac');}catch(e){}})();`;
 
 const interTight = Inter_Tight({
   variable: "--font-inter-tight",
@@ -38,17 +35,22 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const { user } = await withAuth();
-  const showPalette = user !== null && isEmailAllowed(user.email);
+  const isAuthorized = user !== null && isEmailAllowed(user.email);
+  const showPalette = isAuthorized;
+  const prefs = isAuthorized ? await getUserPreferences(user.id) : null;
+  const prefAttrs = prefsToHtmlAttrs(prefs);
+  const preHydrationScript = buildPreHydrationScript(isAuthorized);
 
   return (
     <html
       lang="en"
       className={`${interTight.variable} ${geistMono.variable} h-full antialiased`}
       suppressHydrationWarning
+      {...prefAttrs}
     >
       <body className="min-h-full flex flex-col bg-paper text-ink">
         <Script id="md-pre-hydration" strategy="beforeInteractive">
-          {PRE_HYDRATION_SCRIPT}
+          {preHydrationScript}
         </Script>
         <AuthKitProvider>{children}</AuthKitProvider>
         <BrandMark />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,14 @@ export default async function RootLayout({
   const { user } = await withAuth();
   const isAuthorized = user !== null && isEmailAllowed(user.email);
   const showPalette = isAuthorized;
-  const prefs = isAuthorized ? await getUserPreferences(user.id) : null;
+  let prefs = null;
+  if (isAuthorized) {
+    try {
+      prefs = await getUserPreferences(user.id);
+    } catch (err) {
+      console.warn("[layout] getUserPreferences failed:", err);
+    }
+  }
   const prefAttrs = prefsToHtmlAttrs(prefs);
   const preHydrationScript = buildPreHydrationScript(isAuthorized);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,9 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { withAuth, signOut } from "@workos-inc/authkit-nextjs";
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
+import { signOutAction } from "@/lib/auth-actions";
 import { DocList } from "@/components/doc-list";
-
-async function signOutAction() {
-  "use server";
-  await signOut();
-}
 
 export default async function Home() {
   const { user } = await withAuth();

--- a/src/app/settings/_components/account-section.tsx
+++ b/src/app/settings/_components/account-section.tsx
@@ -1,0 +1,22 @@
+import { signOutAction } from "@/lib/auth-actions";
+import { maskEmail } from "@/lib/mask-email";
+
+export function AccountSection({ email }: { email: string }) {
+  return (
+    <section className="settings__section">
+      <h2 className="settings__section-h">Account</h2>
+
+      <div className="settings__row">
+        <div className="settings__row-label">
+          <div className="settings__row-title">Signed in as</div>
+          <div className="settings__row-help font-mono">{maskEmail(email)}</div>
+        </div>
+        <form action={signOutAction}>
+          <button type="submit" className="settings__sign-out">
+            Sign out
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/src/app/settings/_components/reading-section.tsx
+++ b/src/app/settings/_components/reading-section.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { UserPreferences, Width } from "@/lib/user-preferences";
+import { saveReadingPrefs } from "@/app/settings/actions";
+
+export function ReadingSection({ prefs }: { prefs: UserPreferences }) {
+  const [autoShow, setAutoShow] = useState(prefs.autoShowOutline);
+  const [width, setWidth] = useState<Width>(prefs.defaultWidth);
+  const [error, setError] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  function applyDataAttrs(next: { autoShow?: boolean; width?: Width }) {
+    if (next.autoShow !== undefined) {
+      if (next.autoShow) {
+        document.documentElement.removeAttribute("data-outline-hidden");
+      } else {
+        document.documentElement.setAttribute("data-outline-hidden", "1");
+      }
+    }
+    if (next.width !== undefined) {
+      if (next.width === "wide") {
+        document.documentElement.setAttribute("data-width", "wide");
+      } else {
+        document.documentElement.removeAttribute("data-width");
+      }
+    }
+  }
+
+  function persistAutoShow(next: boolean) {
+    const previous = autoShow;
+    setAutoShow(next);
+    applyDataAttrs({ autoShow: next });
+    setError(null);
+    startTransition(async () => {
+      const result = await saveReadingPrefs({ autoShowOutline: next });
+      if (!result.ok) {
+        setAutoShow(previous);
+        applyDataAttrs({ autoShow: previous });
+        setError(result.error);
+      }
+    });
+  }
+
+  function persistWidth(next: Width) {
+    if (next === width) return;
+    const previous = width;
+    setWidth(next);
+    applyDataAttrs({ width: next });
+    setError(null);
+    startTransition(async () => {
+      const result = await saveReadingPrefs({ defaultWidth: next });
+      if (!result.ok) {
+        setWidth(previous);
+        applyDataAttrs({ width: previous });
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <section className="settings__section">
+      <h2 className="settings__section-h">Reading</h2>
+
+      <div className="settings__row">
+        <div className="settings__row-label">
+          <div className="settings__row-title">Auto-show outline</div>
+          <div className="settings__row-help">
+            Reveal the on-page outline on docs with three or more H2 headings.
+          </div>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={autoShow}
+          aria-label="Auto-show outline"
+          onClick={() => persistAutoShow(!autoShow)}
+          className="settings__toggle"
+          data-on={autoShow}
+        >
+          <span className="settings__toggle-thumb" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="settings__row">
+        <div className="settings__row-label">
+          <div className="settings__row-title">Default width</div>
+          <div className="settings__row-help">
+            Applies to every reader view. The R/W toggle in the reader updates
+            this preference.
+          </div>
+        </div>
+        <div className="settings__pill" role="group" aria-label="Default width">
+          <button
+            type="button"
+            onClick={() => persistWidth("reading")}
+            data-active={width === "reading"}
+            aria-pressed={width === "reading"}
+          >
+            Reading
+          </button>
+          <button
+            type="button"
+            onClick={() => persistWidth("wide")}
+            data-active={width === "wide"}
+            aria-pressed={width === "wide"}
+          >
+            Wide
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <p className="settings__error" role="alert">
+          {error}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/app/settings/_components/settings-back-nav.tsx
+++ b/src/app/settings/_components/settings-back-nav.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+export function SettingsBackNav() {
+  const router = useRouter();
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      if (document.documentElement.dataset.cmdPaletteOpen === "true") return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+      router.back();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [router]);
+
+  return (
+    <div className="settings__back-nav">
+      <Link href="/" className="settings__back-link">
+        ← dashboard
+      </Link>
+    </div>
+  );
+}

--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { isEmailAllowed } from "@/lib/access";
+import {
+  upsertUserPreferences,
+  validatePartialPreferences,
+  type PartialUserPreferences,
+} from "@/lib/user-preferences";
+
+export type SaveResult = { ok: true } | { ok: false; error: string };
+
+async function authedOwnerId(): Promise<string | null> {
+  const { user } = await withAuth();
+  if (!user || !isEmailAllowed(user.email)) return null;
+  return user.id;
+}
+
+export async function saveReadingPrefs(input: {
+  autoShowOutline?: boolean;
+  defaultWidth?: "reading" | "wide";
+}): Promise<SaveResult> {
+  const ownerId = await authedOwnerId();
+  if (!ownerId) return { ok: false, error: "Not authorized" };
+
+  const partial: PartialUserPreferences = {};
+  if (input.autoShowOutline !== undefined) {
+    partial.autoShowOutline = input.autoShowOutline;
+  }
+  if (input.defaultWidth !== undefined) {
+    partial.defaultWidth = input.defaultWidth;
+  }
+
+  const validated = validatePartialPreferences(partial);
+  if (!validated.ok) return { ok: false, error: validated.error };
+  await upsertUserPreferences(ownerId, validated.value);
+  revalidatePath("/settings");
+  revalidatePath("/", "layout");
+  return { ok: true };
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,7 +2,11 @@ import { redirect } from "next/navigation";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
 import { listTokensForOwner } from "@/lib/api-tokens";
+import { getUserPreferences } from "@/lib/user-preferences";
+import { ReadingSection } from "./_components/reading-section";
 import { TokensSection } from "./_components/tokens-section";
+import { AccountSection } from "./_components/account-section";
+import { SettingsBackNav } from "./_components/settings-back-nav";
 
 export const dynamic = "force-dynamic";
 
@@ -17,15 +21,21 @@ export default async function SettingsPage() {
     redirect("/");
   }
 
-  const tokens = await listTokensForOwner(user.id);
+  const [tokens, prefs] = await Promise.all([
+    listTokensForOwner(user.id),
+    getUserPreferences(user.id),
+  ]);
 
   return (
     <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
       <div className="settings">
+        <SettingsBackNav />
         <h1 className="settings__h1">Settings</h1>
         <p className="settings__sub">
-          Preferences and API token management.
+          Reading preferences, API tokens, and account.
         </p>
+
+        <ReadingSection prefs={prefs} />
 
         <section className="settings__section">
           <h2 className="settings__section-h">API tokens</h2>
@@ -44,6 +54,8 @@ export default async function SettingsPage() {
             }))}
           />
         </section>
+
+        <AccountSection email={user.email} />
       </div>
     </main>
   );

--- a/src/app/v/[slug]/page.tsx
+++ b/src/app/v/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { getDocBySlug } from "@/lib/db";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { ReaderShell } from "@/components/reader-shell";
 import { parseHeadings } from "@/lib/heading-utils";
+import { resolveReaderPrefs } from "@/lib/reader-prefs";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -58,6 +59,10 @@ export default async function ViewPage({ params, searchParams }: PageProps) {
 
   const { user } = await withAuth();
   const isAuthed = !!user && isEmailAllowed(user.email);
+  const { initialWidth, initialOutlineShown } = await resolveReaderPrefs({
+    userId: isAuthed ? user!.id : null,
+    hasOutline,
+  });
 
   return (
     <ReaderShell
@@ -66,6 +71,8 @@ export default async function ViewPage({ params, searchParams }: PageProps) {
       hasOutline={hasOutline}
       headings={headings}
       isAuthed={isAuthed}
+      initialWidth={initialWidth}
+      initialOutlineShown={initialOutlineShown}
     >
       <MarkdownRenderer content={doc.content} />
     </ReaderShell>

--- a/src/components/reader-shell.tsx
+++ b/src/components/reader-shell.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState, useTransition, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { OutlineRail } from "./outline-rail";
 import { ReaderToolbar } from "./reader-toolbar";
+import { saveReadingPrefs } from "@/app/settings/actions";
 import type { Heading } from "@/lib/heading-utils";
-
-type Width = "reading" | "wide";
+import type { Width } from "@/lib/user-preferences";
 
 const WIDTH_KEY = "md.width";
 const OUTLINE_KEY = "md.outline.shown";
@@ -17,6 +17,8 @@ export function ReaderShell({
   hasOutline,
   headings,
   isAuthed,
+  initialWidth,
+  initialOutlineShown,
   children,
 }: {
   slug: string;
@@ -24,40 +26,59 @@ export function ReaderShell({
   hasOutline: boolean;
   headings: Heading[];
   isAuthed: boolean;
+  initialWidth: Width;
+  initialOutlineShown: boolean;
   children: ReactNode;
 }) {
-  const [width, setWidth] = useState<Width>("reading");
-  const [outlineShown, setOutlineShown] = useState(hasOutline);
+  const [width, setWidth] = useState<Width>(initialWidth);
+  const [outlineShown, setOutlineShown] = useState(initialOutlineShown);
   const router = useRouter();
   const dashboardHref = isAuthed ? "/" : undefined;
+  const [, startTransition] = useTransition();
 
+  // One-shot sync from localStorage (the unauth source of truth) after
+  // hydration, since the server can't read it. Visual is already correct via
+  // CSS keyed on :root[data-width] / :root[data-outline-hidden] — this just
+  // keeps React state honest for the keyboard handlers below.
   useEffect(() => {
-    const w = localStorage.getItem(WIDTH_KEY) as Width | null;
-    if (w === "reading" || w === "wide") setWidth(w);
+    if (isAuthed) return;
+    const stored = localStorage.getItem(WIDTH_KEY) as Width | null;
+    if (stored === "reading" || stored === "wide") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setWidth(stored);
+    }
     if (hasOutline) {
       const o = localStorage.getItem(OUTLINE_KEY);
       if (o !== null) setOutlineShown(o === "true");
-    } else {
-      setOutlineShown(false);
     }
-  }, [hasOutline]);
+  }, [isAuthed, hasOutline]);
 
   function pickWidth(next: Width) {
     setWidth(next);
-    localStorage.setItem(WIDTH_KEY, next);
     if (next === "wide") document.documentElement.setAttribute("data-width", "wide");
     else document.documentElement.removeAttribute("data-width");
+    if (isAuthed) {
+      startTransition(async () => {
+        await saveReadingPrefs({ defaultWidth: next });
+      });
+    } else {
+      localStorage.setItem(WIDTH_KEY, next);
+    }
   }
 
   function toggleOutline() {
     if (!hasOutline) return;
-    setOutlineShown((prev) => {
-      const next = !prev;
+    const next = !outlineShown;
+    setOutlineShown(next);
+    if (next) document.documentElement.removeAttribute("data-outline-hidden");
+    else document.documentElement.setAttribute("data-outline-hidden", "1");
+    if (isAuthed) {
+      startTransition(async () => {
+        await saveReadingPrefs({ autoShowOutline: next });
+      });
+    } else {
       localStorage.setItem(OUTLINE_KEY, String(next));
-      if (next) document.documentElement.removeAttribute("data-outline-hidden");
-      else document.documentElement.setAttribute("data-outline-hidden", "1");
-      return next;
-    });
+    }
   }
 
   useEffect(() => {
@@ -142,11 +163,12 @@ export function ReaderShell({
         {hasOutline && (
           <button
             type="button"
+            data-outline-toggle
             onClick={toggleOutline}
             aria-label={outlineShown ? "Hide outline" : "Show outline"}
             title={outlineShown ? "Hide outline" : "Show outline"}
             aria-pressed={outlineShown}
-            className="grid size-8 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[background-color,border-color,color] duration-200 hover:border-ochre hover:text-ochre aria-pressed:border-ochre aria-pressed:bg-ochre aria-pressed:text-paper aria-pressed:hover:text-paper"
+            className="reader-outline-toggle grid size-8 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[background-color,border-color,color] duration-200 hover:border-ochre hover:text-ochre"
           >
             <OutlineIcon />
           </button>

--- a/src/components/reader-shell.tsx
+++ b/src/components/reader-shell.tsx
@@ -53,13 +53,34 @@ export function ReaderShell({
     }
   }, [isAuthed, hasOutline]);
 
+  function applyWidthAttr(value: Width) {
+    if (value === "wide") {
+      document.documentElement.setAttribute("data-width", "wide");
+    } else {
+      document.documentElement.removeAttribute("data-width");
+    }
+  }
+
+  function applyOutlineAttr(visible: boolean) {
+    if (visible) {
+      document.documentElement.removeAttribute("data-outline-hidden");
+    } else {
+      document.documentElement.setAttribute("data-outline-hidden", "1");
+    }
+  }
+
   function pickWidth(next: Width) {
+    const previous = width;
     setWidth(next);
-    if (next === "wide") document.documentElement.setAttribute("data-width", "wide");
-    else document.documentElement.removeAttribute("data-width");
+    applyWidthAttr(next);
     if (isAuthed) {
       startTransition(async () => {
-        await saveReadingPrefs({ defaultWidth: next });
+        const result = await saveReadingPrefs({ defaultWidth: next });
+        if (!result.ok) {
+          console.warn("[reader] saveReadingPrefs failed:", result.error);
+          setWidth(previous);
+          applyWidthAttr(previous);
+        }
       });
     } else {
       localStorage.setItem(WIDTH_KEY, next);
@@ -68,13 +89,18 @@ export function ReaderShell({
 
   function toggleOutline() {
     if (!hasOutline) return;
+    const previous = outlineShown;
     const next = !outlineShown;
     setOutlineShown(next);
-    if (next) document.documentElement.removeAttribute("data-outline-hidden");
-    else document.documentElement.setAttribute("data-outline-hidden", "1");
+    applyOutlineAttr(next);
     if (isAuthed) {
       startTransition(async () => {
-        await saveReadingPrefs({ autoShowOutline: next });
+        const result = await saveReadingPrefs({ autoShowOutline: next });
+        if (!result.ok) {
+          console.warn("[reader] saveReadingPrefs failed:", result.error);
+          setOutlineShown(previous);
+          applyOutlineAttr(previous);
+        }
       });
     } else {
       localStorage.setItem(OUTLINE_KEY, String(next));

--- a/src/components/reader-toolbar.tsx
+++ b/src/components/reader-toolbar.tsx
@@ -45,12 +45,12 @@ function WidthPill({
         <button
           key={w}
           type="button"
-          data-active={value === w ? "true" : undefined}
+          data-width-pill={w}
           onClick={() => onChange(w)}
           aria-label={`Width: ${w}`}
           title={w === "reading" ? "Reading width" : "Wide width"}
           aria-pressed={value === w}
-          className="cursor-pointer border-0 bg-transparent py-1 font-mono text-[0.625rem] font-medium leading-none tracking-[0.04em] text-muted aria-pressed:bg-ochre aria-pressed:font-semibold aria-pressed:text-paper"
+          className="reader-toolbar__width-btn cursor-pointer border-0 bg-transparent py-1 font-mono text-[0.625rem] font-medium leading-none tracking-[0.04em] text-muted"
         >
           {w === "reading" ? "R" : "W"}
         </button>

--- a/src/lib/auth-actions.ts
+++ b/src/lib/auth-actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { signOut } from "@workos-inc/authkit-nextjs";
+
+export async function signOutAction() {
+  await signOut();
+}

--- a/src/lib/mask-email.test.ts
+++ b/src/lib/mask-email.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { maskEmail } from "./mask-email";
+
+describe("maskEmail", () => {
+  it("keeps the first character of the local part and replaces the rest with asterisks", () => {
+    expect(maskEmail("mark.d.lozano@gmail.com")).toBe("m************@gmail.com");
+  });
+
+  it("preserves a single-character local part by emitting only the first char (no asterisks)", () => {
+    expect(maskEmail("a@x.io")).toBe("a@x.io");
+  });
+
+  it("handles a two-character local part with one asterisk", () => {
+    expect(maskEmail("ab@x.io")).toBe("a*@x.io");
+  });
+
+  it("preserves the domain casing", () => {
+    expect(maskEmail("Foo.Bar@Example.COM")).toBe("F******@Example.COM");
+  });
+
+  it("returns the original string when there is no @", () => {
+    expect(maskEmail("not-an-email")).toBe("not-an-email");
+  });
+
+  it("returns the original string when the local part is empty", () => {
+    expect(maskEmail("@example.com")).toBe("@example.com");
+  });
+});

--- a/src/lib/mask-email.ts
+++ b/src/lib/mask-email.ts
@@ -1,0 +1,12 @@
+/**
+ * Masks the local part of an email so screenshots, support sessions, and
+ * shoulder-surfers don't reveal the full address. Keeps the first character
+ * and the full domain; replaces the remaining local-part chars with `*`.
+ */
+export function maskEmail(email: string): string {
+  const at = email.indexOf("@");
+  if (at <= 0) return email;
+  const local = email.slice(0, at);
+  const domain = email.slice(at);
+  return local[0] + "*".repeat(local.length - 1) + domain;
+}

--- a/src/lib/pre-hydration-script.test.ts
+++ b/src/lib/pre-hydration-script.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { buildPreHydrationScript } from "./pre-hydration-script";
+
+describe("buildPreHydrationScript", () => {
+  describe("when the request is authed", () => {
+    const script = buildPreHydrationScript(true);
+
+    it("does NOT read md.width from localStorage (server attrs are authoritative)", () => {
+      expect(script).not.toContain("md.width");
+    });
+
+    it("does NOT read md.outline.shown from localStorage", () => {
+      expect(script).not.toContain("md.outline.shown");
+    });
+
+    it("does NOT set data-width client-side", () => {
+      expect(script).not.toContain("data-width");
+    });
+
+    it("does NOT set data-outline-hidden client-side", () => {
+      expect(script).not.toContain("data-outline-hidden");
+    });
+
+    it("still reads md.dev-theme (dev-only theme switcher remains client-side)", () => {
+      expect(script).toContain("md.dev-theme");
+    });
+
+    it("still detects mac platform from UA", () => {
+      expect(script).toContain("data-platform");
+    });
+  });
+
+  describe("when the request is unauthed", () => {
+    const script = buildPreHydrationScript(false);
+
+    it("reads md.width from localStorage", () => {
+      expect(script).toContain("md.width");
+    });
+
+    it("reads md.outline.shown from localStorage", () => {
+      expect(script).toContain("md.outline.shown");
+    });
+
+    it("sets data-width when wide", () => {
+      expect(script).toContain("data-width");
+    });
+
+    it("sets data-outline-hidden when shown=false", () => {
+      expect(script).toContain("data-outline-hidden");
+    });
+
+    it("still reads md.dev-theme", () => {
+      expect(script).toContain("md.dev-theme");
+    });
+
+    it("still detects mac platform", () => {
+      expect(script).toContain("data-platform");
+    });
+  });
+
+  describe("safety", () => {
+    it("wraps the body in try/catch so a bad localStorage doesn't break first paint (authed)", () => {
+      const script = buildPreHydrationScript(true);
+      expect(script).toMatch(/try\s*{/);
+      expect(script).toMatch(/catch\s*\(/);
+    });
+
+    it("wraps the body in try/catch (unauthed)", () => {
+      const script = buildPreHydrationScript(false);
+      expect(script).toMatch(/try\s*{/);
+      expect(script).toMatch(/catch\s*\(/);
+    });
+
+    it("returns an IIFE so identifiers don't leak to window scope", () => {
+      const script = buildPreHydrationScript(false);
+      expect(script.trimStart().startsWith("(function()")).toBe(true);
+      expect(script.trimEnd().endsWith("})();")).toBe(true);
+    });
+  });
+});

--- a/src/lib/pre-hydration-script.ts
+++ b/src/lib/pre-hydration-script.ts
@@ -1,0 +1,24 @@
+/**
+ * Builds the inline script string for `next/script` `beforeInteractive`
+ * pre-hydration. Two responsibilities:
+ *
+ *   - Apply the user's reader preferences (width, outline auto-show) before
+ *     first paint, to avoid a flash of wrong state.
+ *   - Apply UA-detected platform + dev theme switcher state.
+ *
+ * For authed users, layout.tsx renders authoritative `<html>` data-attrs
+ * server-side from `getUserPreferences`. The localStorage reads are skipped
+ * so stale client values can't override the server's decision. Unauthed
+ * readers (public links) keep the localStorage path as their only state.
+ */
+export function buildPreHydrationScript(authed: boolean): string {
+  const localStorageReaderPrefs = `var w=localStorage.getItem('md.width');if(w==='wide')document.documentElement.setAttribute('data-width','wide');var o=localStorage.getItem('md.outline.shown');if(o==='false')document.documentElement.setAttribute('data-outline-hidden','1');`;
+
+  const devThemeAndPlatform = `var t=localStorage.getItem('md.dev-theme');if(t==='light'||t==='dark'){document.documentElement.setAttribute('data-theme',t);document.documentElement.setAttribute('data-dev-theme',t);}var ua=navigator.userAgent||'';var p=(navigator.userAgentData&&navigator.userAgentData.platform)||'';if(/Mac|iPhone|iPad/.test(ua)||/macOS|iOS/.test(p))document.documentElement.setAttribute('data-platform','mac');`;
+
+  const body = authed
+    ? devThemeAndPlatform
+    : `${localStorageReaderPrefs}${devThemeAndPlatform}`;
+
+  return `(function(){try{${body}}catch(e){}})();`;
+}

--- a/src/lib/prefs-html-attrs.test.ts
+++ b/src/lib/prefs-html-attrs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { prefsToHtmlAttrs } from "./prefs-html-attrs";
+import { DEFAULT_PREFERENCES } from "./user-preferences";
+
+describe("prefsToHtmlAttrs", () => {
+  it("returns an empty object for null prefs (unauth fallback path)", () => {
+    expect(prefsToHtmlAttrs(null)).toEqual({});
+  });
+
+  it("returns an empty object for the canonical defaults", () => {
+    expect(prefsToHtmlAttrs(DEFAULT_PREFERENCES)).toEqual({});
+  });
+
+  it("emits data-width=wide when defaultWidth is wide", () => {
+    expect(
+      prefsToHtmlAttrs({
+        ...DEFAULT_PREFERENCES,
+        defaultWidth: "wide",
+      }),
+    ).toEqual({ "data-width": "wide" });
+  });
+
+  it("does not emit data-width when defaultWidth is reading", () => {
+    expect(
+      prefsToHtmlAttrs({
+        ...DEFAULT_PREFERENCES,
+        defaultWidth: "reading",
+      }),
+    ).toEqual({});
+  });
+
+  it("emits data-outline-hidden=1 when autoShowOutline is false", () => {
+    expect(
+      prefsToHtmlAttrs({
+        ...DEFAULT_PREFERENCES,
+        autoShowOutline: false,
+      }),
+    ).toEqual({ "data-outline-hidden": "1" });
+  });
+
+  it("merges both attributes when both prefs are non-default", () => {
+    expect(
+      prefsToHtmlAttrs({
+        autoShowOutline: false,
+        defaultWidth: "wide",
+      }),
+    ).toEqual({
+      "data-width": "wide",
+      "data-outline-hidden": "1",
+    });
+  });
+});

--- a/src/lib/prefs-html-attrs.ts
+++ b/src/lib/prefs-html-attrs.ts
@@ -1,0 +1,24 @@
+import type { UserPreferences } from "@/lib/user-preferences";
+
+export type HtmlPrefAttrs = {
+  "data-width"?: "wide";
+  "data-outline-hidden"?: "1";
+};
+
+/**
+ * Maps a user's stored preferences to the data attributes the layout sets on
+ * <html>. Mirrors the inline pre-hydration script's localStorage path; for
+ * authed users the layout reads prefs server-side and emits the attributes
+ * directly, so first paint is correct without an inline-script round trip.
+ *
+ * Only non-default values produce attributes — defaults are absence.
+ */
+export function prefsToHtmlAttrs(
+  prefs: UserPreferences | null,
+): HtmlPrefAttrs {
+  if (!prefs) return {};
+  const attrs: HtmlPrefAttrs = {};
+  if (prefs.defaultWidth === "wide") attrs["data-width"] = "wide";
+  if (prefs.autoShowOutline === false) attrs["data-outline-hidden"] = "1";
+  return attrs;
+}

--- a/src/lib/reader-prefs-flow.test.ts
+++ b/src/lib/reader-prefs-flow.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { prefsToHtmlAttrs } from "./prefs-html-attrs";
+import { buildPreHydrationScript } from "./pre-hydration-script";
+import { resolveReaderPrefsFromPrefs } from "./reader-prefs";
+import type { UserPreferences } from "./user-preferences";
+
+const allPrefStates: UserPreferences[] = [
+  { autoShowOutline: true, defaultWidth: "reading" },
+  { autoShowOutline: true, defaultWidth: "wide" },
+  { autoShowOutline: false, defaultWidth: "reading" },
+  { autoShowOutline: false, defaultWidth: "wide" },
+];
+
+describe("authed reader-prefs flow contract", () => {
+  describe.each(allPrefStates)(
+    "with prefs autoShowOutline=$autoShowOutline, defaultWidth=$defaultWidth",
+    (prefs) => {
+      const serverAttrs = prefsToHtmlAttrs(prefs);
+      const script = buildPreHydrationScript(true);
+      const reader = resolveReaderPrefsFromPrefs(prefs, true);
+
+      it("the pre-hydration script does not read the same localStorage keys the server already emitted attrs for", () => {
+        expect(script).not.toContain("md.width");
+        expect(script).not.toContain("md.outline.shown");
+      });
+
+      it("the server-emitted data-width attribute matches the resolved initial reader width", () => {
+        const serverWidth = serverAttrs["data-width"];
+        if (reader.initialWidth === "wide") {
+          expect(serverWidth).toBe("wide");
+        } else {
+          expect(serverWidth).toBeUndefined();
+        }
+      });
+
+      it("the server-emitted data-outline-hidden attribute matches the resolved initial outline state", () => {
+        const serverOutlineHidden = serverAttrs["data-outline-hidden"];
+        if (reader.initialOutlineShown) {
+          expect(serverOutlineHidden).toBeUndefined();
+        } else {
+          expect(serverOutlineHidden).toBe("1");
+        }
+      });
+    },
+  );
+});
+
+describe("unauthed reader-prefs flow contract", () => {
+  it("prefsToHtmlAttrs returns empty for null prefs (so the server emits no attrs and the script's localStorage path is solely responsible)", () => {
+    expect(prefsToHtmlAttrs(null)).toEqual({});
+  });
+
+  it("the pre-hydration script reads the localStorage keys for reader prefs", () => {
+    const script = buildPreHydrationScript(false);
+    expect(script).toContain("md.width");
+    expect(script).toContain("md.outline.shown");
+  });
+
+  it("resolveReaderPrefsFromPrefs falls back to width=reading + outline-shown=hasOutline", () => {
+    expect(resolveReaderPrefsFromPrefs(null, true)).toEqual({
+      initialWidth: "reading",
+      initialOutlineShown: true,
+    });
+    expect(resolveReaderPrefsFromPrefs(null, false)).toEqual({
+      initialWidth: "reading",
+      initialOutlineShown: false,
+    });
+  });
+});
+
+describe("regression — bugs reported during PR review", () => {
+  it("bug 1: when autoShowOutline=true, server emits no data-outline-hidden AND the authed script never sets it (so refresh stays consistent with the toggle)", () => {
+    const prefs: UserPreferences = {
+      autoShowOutline: true,
+      defaultWidth: "reading",
+    };
+    const serverAttrs = prefsToHtmlAttrs(prefs);
+    const script = buildPreHydrationScript(true);
+    expect(serverAttrs["data-outline-hidden"]).toBeUndefined();
+    expect(script).not.toContain("data-outline-hidden");
+  });
+
+  it("bug 2: when defaultWidth=reading, server emits no data-width AND the authed script never sets it (so toggling wide→reading→refresh stays reading)", () => {
+    const prefs: UserPreferences = {
+      autoShowOutline: true,
+      defaultWidth: "reading",
+    };
+    const serverAttrs = prefsToHtmlAttrs(prefs);
+    const script = buildPreHydrationScript(true);
+    expect(serverAttrs["data-width"]).toBeUndefined();
+    expect(script).not.toContain("data-width");
+  });
+});

--- a/src/lib/reader-prefs.test.ts
+++ b/src/lib/reader-prefs.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveReaderPrefsFromPrefs } from "./reader-prefs";
+import { DEFAULT_PREFERENCES } from "./user-preferences";
+
+describe("resolveReaderPrefsFromPrefs", () => {
+  it("falls back to reading width and shows outline when prefs are null and the doc has an outline", () => {
+    expect(resolveReaderPrefsFromPrefs(null, true)).toEqual({
+      initialWidth: "reading",
+      initialOutlineShown: true,
+    });
+  });
+
+  it("forces outline closed when the doc lacks one, regardless of preference", () => {
+    expect(
+      resolveReaderPrefsFromPrefs(DEFAULT_PREFERENCES, false),
+    ).toEqual({ initialWidth: "reading", initialOutlineShown: false });
+  });
+
+  it("respects defaultWidth=wide", () => {
+    const prefs = { ...DEFAULT_PREFERENCES, defaultWidth: "wide" as const };
+    expect(resolveReaderPrefsFromPrefs(prefs, true).initialWidth).toBe("wide");
+  });
+
+  it("hides the outline when autoShowOutline is off, even on docs that have one", () => {
+    const prefs = { ...DEFAULT_PREFERENCES, autoShowOutline: false };
+    expect(resolveReaderPrefsFromPrefs(prefs, true).initialOutlineShown).toBe(
+      false,
+    );
+  });
+
+  it("shows outline when autoShowOutline is on and the doc has one", () => {
+    expect(
+      resolveReaderPrefsFromPrefs(DEFAULT_PREFERENCES, true).initialOutlineShown,
+    ).toBe(true);
+  });
+});

--- a/src/lib/reader-prefs.ts
+++ b/src/lib/reader-prefs.ts
@@ -1,0 +1,40 @@
+import {
+  getUserPreferences,
+  type UserPreferences,
+  type Width,
+} from "@/lib/user-preferences";
+
+export type ResolvedReaderPrefs = {
+  initialWidth: Width;
+  initialOutlineShown: boolean;
+};
+
+/**
+ * Pure resolver: given a user's prefs (or null for unauth) and whether the
+ * doc has an outline (≥3 H2s, decided upstream), produce the initial reader
+ * state. The ≥3 H2 gate is preserved as a quality floor — pref says "may
+ * auto-show", not "always auto-show".
+ */
+export function resolveReaderPrefsFromPrefs(
+  prefs: UserPreferences | null,
+  hasOutline: boolean,
+): ResolvedReaderPrefs {
+  if (!hasOutline) {
+    return {
+      initialWidth: prefs?.defaultWidth ?? "reading",
+      initialOutlineShown: false,
+    };
+  }
+  return {
+    initialWidth: prefs?.defaultWidth ?? "reading",
+    initialOutlineShown: prefs ? prefs.autoShowOutline : true,
+  };
+}
+
+export async function resolveReaderPrefs(args: {
+  userId: string | null;
+  hasOutline: boolean;
+}): Promise<ResolvedReaderPrefs> {
+  const prefs = args.userId ? await getUserPreferences(args.userId) : null;
+  return resolveReaderPrefsFromPrefs(prefs, args.hasOutline);
+}

--- a/src/lib/reader-prefs.ts
+++ b/src/lib/reader-prefs.ts
@@ -35,6 +35,13 @@ export async function resolveReaderPrefs(args: {
   userId: string | null;
   hasOutline: boolean;
 }): Promise<ResolvedReaderPrefs> {
-  const prefs = args.userId ? await getUserPreferences(args.userId) : null;
+  let prefs: UserPreferences | null = null;
+  if (args.userId) {
+    try {
+      prefs = await getUserPreferences(args.userId);
+    } catch (err) {
+      console.warn("[reader-prefs] getUserPreferences failed:", err);
+    }
+  }
   return resolveReaderPrefsFromPrefs(prefs, args.hasOutline);
 }

--- a/src/lib/user-preferences.test.ts
+++ b/src/lib/user-preferences.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PREFERENCES,
+  mergeWithDefaults,
+  validatePartialPreferences,
+} from "./user-preferences";
+
+describe("DEFAULT_PREFERENCES", () => {
+  it("matches the migration defaults", () => {
+    expect(DEFAULT_PREFERENCES).toEqual({
+      autoShowOutline: true,
+      defaultWidth: "reading",
+    });
+  });
+});
+
+describe("mergeWithDefaults", () => {
+  it("returns the canonical defaults when no row exists", () => {
+    expect(mergeWithDefaults(null)).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("preserves stored values over defaults", () => {
+    const result = mergeWithDefaults({
+      auto_show_outline: false,
+      default_width: "wide",
+    });
+    expect(result).toEqual({
+      autoShowOutline: false,
+      defaultWidth: "wide",
+    });
+  });
+});
+
+describe("validatePartialPreferences", () => {
+  it("accepts an empty input", () => {
+    const result = validatePartialPreferences({});
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({});
+  });
+
+  it("accepts a valid auto_show_outline boolean", () => {
+    const result = validatePartialPreferences({ autoShowOutline: false });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.autoShowOutline).toBe(false);
+  });
+
+  it("rejects a non-boolean auto_show_outline", () => {
+    const result = validatePartialPreferences({
+      autoShowOutline: "false" as unknown as boolean,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts default_width 'reading' and 'wide'", () => {
+    expect(validatePartialPreferences({ defaultWidth: "reading" }).ok).toBe(
+      true,
+    );
+    expect(validatePartialPreferences({ defaultWidth: "wide" }).ok).toBe(true);
+  });
+
+  it("rejects an unknown default_width", () => {
+    const result = validatePartialPreferences({
+      defaultWidth: "huge" as unknown as "reading",
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/lib/user-preferences.ts
+++ b/src/lib/user-preferences.ts
@@ -1,0 +1,98 @@
+import { sql } from "@/lib/db";
+
+export type Width = "reading" | "wide";
+
+export type UserPreferences = {
+  autoShowOutline: boolean;
+  defaultWidth: Width;
+};
+
+export type PartialUserPreferences = Partial<UserPreferences>;
+
+export const DEFAULT_PREFERENCES: UserPreferences = {
+  autoShowOutline: true,
+  defaultWidth: "reading",
+};
+
+type UserPreferencesRow = {
+  auto_show_outline: boolean;
+  default_width: string;
+};
+
+export type ValidatedPartial =
+  | { ok: true; value: PartialUserPreferences }
+  | { ok: false; error: string };
+
+export function mergeWithDefaults(
+  row: UserPreferencesRow | null,
+): UserPreferences {
+  if (!row) return { ...DEFAULT_PREFERENCES };
+  return {
+    autoShowOutline: row.auto_show_outline,
+    defaultWidth: row.default_width === "wide" ? "wide" : "reading",
+  };
+}
+
+export function validatePartialPreferences(
+  input: PartialUserPreferences,
+): ValidatedPartial {
+  const value: PartialUserPreferences = {};
+
+  if (input.autoShowOutline !== undefined) {
+    if (typeof input.autoShowOutline !== "boolean") {
+      return { ok: false, error: "autoShowOutline must be a boolean" };
+    }
+    value.autoShowOutline = input.autoShowOutline;
+  }
+
+  if (input.defaultWidth !== undefined) {
+    if (input.defaultWidth !== "reading" && input.defaultWidth !== "wide") {
+      return { ok: false, error: "defaultWidth must be 'reading' or 'wide'" };
+    }
+    value.defaultWidth = input.defaultWidth;
+  }
+
+  return { ok: true, value };
+}
+
+export async function getUserPreferences(
+  ownerId: string,
+): Promise<UserPreferences> {
+  const result = await sql<UserPreferencesRow>`
+    SELECT auto_show_outline, default_width
+    FROM user_preferences
+    WHERE owner_id = ${ownerId}
+    LIMIT 1
+  `;
+  return mergeWithDefaults(result.rows[0] ?? null);
+}
+
+export async function upsertUserPreferences(
+  ownerId: string,
+  partial: PartialUserPreferences,
+): Promise<UserPreferences> {
+  const validated = validatePartialPreferences(partial);
+  if (!validated.ok) throw new Error(validated.error);
+  const merged: UserPreferences = {
+    ...DEFAULT_PREFERENCES,
+    ...validated.value,
+  };
+
+  const result = await sql<UserPreferencesRow>`
+    INSERT INTO user_preferences (
+      owner_id, auto_show_outline, default_width, updated_at
+    )
+    VALUES (
+      ${ownerId},
+      ${merged.autoShowOutline},
+      ${merged.defaultWidth},
+      now()
+    )
+    ON CONFLICT (owner_id) DO UPDATE SET
+      auto_show_outline = COALESCE(${validated.value.autoShowOutline ?? null}, user_preferences.auto_show_outline),
+      default_width     = COALESCE(${validated.value.defaultWidth ?? null}, user_preferences.default_width),
+      updated_at = now()
+    RETURNING auto_show_outline, default_width
+  `;
+  return mergeWithDefaults(result.rows[0] ?? null);
+}


### PR DESCRIPTION
Closes #24.

## Summary

- New **Reading** section on `/settings`: auto-show outline toggle + default-width pill (R/W). Drives reader behavior runtime — toggling the reader's R/W pill writes through to this preference.
- New **Account** section: masked email (first letter + asterisks + domain) and Sign out.
- Settings card now has a **← dashboard** link top-right, plus an Esc handler that returns to the previous page (skips when cmd palette / token modal is open or when typing in an input).
- Defaults section dropped before merge — pending the kind/tags direction. The infrastructure ships (`user_preferences` table, server actions, validation), so we can re-add it without touching plumbing.

## Architecture

Each surface area is a deep module: narrow interface, hidden implementation. Callers (layout, `/v/[slug]`, `/new`, `ReaderShell`, settings sections) only import the seam:

- `lib/user-preferences` — `getUserPreferences(ownerId)`, `upsertUserPreferences(ownerId, partial)`, plus pure `mergeWithDefaults` + `validatePartialPreferences`.
- `lib/prefs-html-attrs` — `prefsToHtmlAttrs(prefs | null)` → `{ "data-width"?, "data-outline-hidden"? }`. Layout server-renders these onto `<html>` for authed users.
- `lib/pre-hydration-script` — `buildPreHydrationScript(authed)`. Authed users skip the localStorage reads (server attrs are authoritative); unauthed users keep the full pre-hydration path.
- `lib/reader-prefs` — `resolveReaderPrefs({ userId, hasOutline })` resolves initial reader state, preserving the ≥3-H2 quality floor.
- `lib/mask-email` — `maskEmail(email)` keeps first char + length-proportional asterisks + domain.
- `lib/auth-actions` — `signOutAction` extracted from `layout.tsx`.

## Bug fixes surfaced during PR

- **Outline-state inconsistency on refresh.** Stale `localStorage.md.outline.shown` was overriding the server's authoritative pref. Fix: pre-hydration script no longer reads those keys for authed users.
- **Width refreshing back to wide after toggling reading.** Same root cause.
- **`Cannot call startTransition while rendering`.** `toggleOutline` was calling `startTransition` from inside a `setState` updater; moved side effects out.
- **Toolbar flash for unauthed users.** Width pill / outline toggle visual now keys off `:root[data-width]` / `:root[data-outline-hidden]` (set synchronously by the inline script) rather than React's `aria-pressed` lag. `aria-pressed` stays for screen readers.

## Tests

86 passing across 8 files. New test files cover every pure helper red→green; cross-module consistency suite (`reader-prefs-flow.test.ts`) pins the contract that prevented the original bugs.

## Notes

- Eslint config now ignores `.claude/**` (vendored skill scripts that were producing 97 noise warnings — none in `src/`).
- Migration 004 ships with the original `default_kind` column for history-correctness; 005 drops it. Net effect on a fresh DB: a clean two-column table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user preferences settings: toggle for outline visibility and width selection (reading/wide)
  * Account section in settings displaying masked email and sign-out option
  * Back navigation in settings with Escape key support

* **Chores**
  * Updated ESLint configuration to exclude Claude Code bundles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->