### PR TITLE
feat: refine palette hotkey discovery

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -225,13 +225,19 @@ button:not(:disabled) {
   background: oklch(20% 0.014 240 / 0.45);
 }
 
+.hotkey-sheet-backdrop {
+  background: oklch(20% 0.014 240 / 0.45);
+}
+
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .cmd-palette-backdrop {
+  :root:not([data-theme="light"]) .cmd-palette-backdrop,
+  :root:not([data-theme="light"]) .hotkey-sheet-backdrop {
     background: oklch(0% 0 0 / 0.6);
   }
 }
 
-:root[data-theme="dark"] .cmd-palette-backdrop {
+:root[data-theme="dark"] .cmd-palette-backdrop,
+:root[data-theme="dark"] .hotkey-sheet-backdrop {
   background: oklch(0% 0 0 / 0.6);
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { prefsToHtmlAttrs } from "@/lib/prefs-html-attrs";
 import { buildPreHydrationScript } from "@/lib/pre-hydration-script";
 import { DevThemeSwitcher } from "@/components/dev-theme-switcher";
 import { CmdPalette } from "@/components/cmd-palette";
+import { HotkeyCheatSheet } from "@/components/hotkey-cheat-sheet";
 import { BrandMark } from "@/components/brand-mark";
 import { DropAnywhere } from "@/components/drop-anywhere";
 import "./globals.css";
@@ -63,6 +64,7 @@ export default async function RootLayout({
         <BrandMark />
         {process.env.NODE_ENV === "development" && <DevThemeSwitcher />}
         {showPalette && <CmdPalette signOutAction={signOutAction} />}
+        <HotkeyCheatSheet isAuthed={isAuthorized} />
         {showPalette && <DropAnywhere />}
       </body>
     </html>

--- a/src/components/cmd-palette.tsx
+++ b/src/components/cmd-palette.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { useRouter, usePathname } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 const PALETTE_OPEN_EVENT = "md:cmd-palette:open";
 const SEARCH_DEBOUNCE_MS = 120;
-const RESULT_LIMIT = 8;
+const RECENT_LIMIT = 3;
+const SEARCH_LIMIT = 8;
 
 type DocResult = {
   id: string;
@@ -17,7 +18,6 @@ type ActionItem = {
   id: string;
   title: string;
   icon: ReactNode;
-  kbd?: string[];
   run: () => void | Promise<void>;
 };
 
@@ -44,7 +44,6 @@ export function CmdPalette({ signOutAction }: Props) {
     close: () => {},
   });
   const router = useRouter();
-  const pathname = usePathname() ?? "/";
 
   function close() {
     setQuery("");
@@ -110,6 +109,10 @@ export function CmdPalette({ signOutAction }: Props) {
         reset();
         return;
       }
+      if (document.documentElement.dataset.hotkeysOpen === "true") {
+        reset();
+        return;
+      }
       if (waiting && (e.key === "d" || e.key === "D")) {
         e.preventDefault();
         reset();
@@ -151,9 +154,10 @@ export function CmdPalette({ signOutAction }: Props) {
   useEffect(() => {
     if (!open) return;
     const trimmed = query.trim();
+    const limit = trimmed ? SEARCH_LIMIT : RECENT_LIMIT;
     const url = trimmed
-      ? `/api/list?search=${encodeURIComponent(trimmed)}&limit=${RESULT_LIMIT}`
-      : `/api/list?limit=${RESULT_LIMIT}`;
+      ? `/api/list?search=${encodeURIComponent(trimmed)}&limit=${limit}`
+      : `/api/list?limit=${limit}`;
     const ctrl = new AbortController();
     const handle = window.setTimeout(() => {
       setDocsLoading(true);
@@ -174,94 +178,8 @@ export function CmdPalette({ signOutAction }: Props) {
     };
   }, [open, query]);
 
-  const isDashboard = pathname === "/";
-  const isReader = pathname.startsWith("/v/");
-  const isEdit = pathname.startsWith("/edit/");
-  const isSettings = pathname === "/settings";
-  const docSlug =
-    isReader || isEdit ? decodeURIComponent(pathname.split("/")[2] ?? "") : "";
-
-  const actions: ActionItem[] = [];
-
-  if (!isDashboard) {
-    actions.push({
-      id: "go-dashboard",
-      title: "Back to dashboard",
-      icon: <BackIcon />,
-      kbd: ["g", "d"],
-      run: () => {
-        close();
-        router.push("/");
-      },
-    });
-  }
-
-  actions.push({
-    id: "new-document",
-    title: "New document",
-    icon: <NewIcon />,
-    kbd: ["g", "n"],
-    run: () => {
-      close();
-      router.push("/new");
-    },
-  });
-
-  if (isReader && docSlug) {
-    actions.push({
-      id: "edit-doc",
-      title: "Edit this document",
-      icon: <EditIcon />,
-      run: () => {
-        close();
-        router.push(`/edit/${docSlug}`);
-      },
-    });
-  }
-
-  if (isEdit && docSlug) {
-    actions.push({
-      id: "view-doc",
-      title: "View this document",
-      icon: <DocIcon />,
-      run: () => {
-        close();
-        router.push(`/v/${docSlug}`);
-      },
-    });
-  }
-
-  if (isReader && docSlug) {
-    actions.push({
-      id: "view-raw",
-      title: "View raw markdown",
-      icon: <RawIcon />,
-      run: () => {
-        close();
-        window.location.assign(`/api/raw/${docSlug}`);
-      },
-    });
-  }
-
-  if ((isReader || isEdit) && docSlug) {
-    actions.push({
-      id: "copy-link",
-      title: "Copy link to this document",
-      icon: <LinkIcon />,
-      run: async () => {
-        const url = `${window.location.origin}/v/${docSlug}`;
-        try {
-          await navigator.clipboard.writeText(url);
-        } catch {
-          // clipboard denied; silent
-        }
-        close();
-      },
-    });
-  }
-
-  if (!isSettings) {
-    actions.push({
+  const actions: ActionItem[] = [
+    {
       id: "open-settings",
       title: "Open settings",
       icon: <SettingsIcon />,
@@ -269,8 +187,8 @@ export function CmdPalette({ signOutAction }: Props) {
         close();
         router.push("/settings");
       },
-    });
-  }
+    },
+  ];
 
   if (signOutAction) {
     actions.push({
@@ -389,7 +307,7 @@ export function CmdPalette({ signOutAction }: Props) {
           ) : (
             <>
               {docs.length > 0 && (
-                <Group label="Documents">
+                <Group label={query.trim() ? "Documents" : "Recent"}>
                   {docs.map((d, i) => (
                     <Row
                       key={d.id}
@@ -417,7 +335,6 @@ export function CmdPalette({ signOutAction }: Props) {
                         onClick={() => pick(idx)}
                         icon={a.icon}
                         title={a.title}
-                        kbd={a.kbd}
                       />
                     );
                   })}
@@ -455,7 +372,6 @@ function Row({
   icon,
   title,
   meta,
-  kbd,
 }: {
   id?: string;
   selected: boolean;
@@ -464,7 +380,6 @@ function Row({
   icon: ReactNode;
   title: string;
   meta?: string;
-  kbd?: string[];
 }) {
   return (
     <button
@@ -484,18 +399,6 @@ function Row({
       {meta && (
         <span className="shrink-0 font-mono text-[0.6875rem] text-muted [font-feature-settings:'tnum']">
           {meta}
-        </span>
-      )}
-      {kbd && (
-        <span className="flex shrink-0 items-center gap-1">
-          {kbd.map((k, i) => (
-            <kbd
-              key={i}
-              className="rounded-[3px] border border-border px-[5px] py-[1px] font-mono text-[0.6875rem] font-medium text-muted"
-            >
-              {k}
-            </kbd>
-          ))}
         </span>
       )}
     </button>
@@ -556,17 +459,6 @@ function DocIcon() {
   );
 }
 
-function NewIcon() {
-  return (
-    <svg {...strokeProps("size-3.5")}>
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-      <path d="M14 2v6h6" />
-      <line x1="12" y1="12" x2="12" y2="18" />
-      <line x1="9" y1="15" x2="15" y2="15" />
-    </svg>
-  );
-}
-
 function SettingsIcon() {
   return (
     <svg {...strokeProps("size-3.5")}>
@@ -582,42 +474,6 @@ function SignOutIcon() {
       <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
       <polyline points="16 17 21 12 16 7" />
       <line x1="21" y1="12" x2="9" y2="12" />
-    </svg>
-  );
-}
-
-function EditIcon() {
-  return (
-    <svg {...strokeProps("size-3.5")}>
-      <path d="M12 20h9" />
-      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />
-    </svg>
-  );
-}
-
-function RawIcon() {
-  return (
-    <svg {...strokeProps("size-3.5")}>
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-      <path d="M14 2v6h6" />
-    </svg>
-  );
-}
-
-function LinkIcon() {
-  return (
-    <svg {...strokeProps("size-3.5")}>
-      <path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 1 0-7.07-7.07L11 5" />
-      <path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 1 0 7.07 7.07L13 19" />
-    </svg>
-  );
-}
-
-function BackIcon() {
-  return (
-    <svg {...strokeProps("size-3.5")}>
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
     </svg>
   );
 }

--- a/src/components/edit-form.tsx
+++ b/src/components/edit-form.tsx
@@ -106,6 +106,7 @@ export function EditForm({
       }
       if (e.key === "Escape") {
         if (document.documentElement.dataset.cmdPaletteOpen === "true") return;
+        if (document.documentElement.dataset.hotkeysOpen === "true") return;
         const target = e.target as HTMLElement | null;
         const tag = target?.tagName;
         if (tag === "INPUT" || tag === "TEXTAREA") {
@@ -165,6 +166,14 @@ export function EditForm({
           {statusLabel}
         </span>
         <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => router.push(`/v/${slug}`)}
+            title="View document"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border bg-paper px-3 py-1.5 text-[0.8125rem] font-semibold text-ink transition-[border-color,color] duration-150 hover:border-ochre hover:text-ochre"
+          >
+            View
+          </button>
           <button
             type="button"
             onClick={cancel}

--- a/src/components/hotkey-cheat-sheet.tsx
+++ b/src/components/hotkey-cheat-sheet.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Hotkey = {
+  label: string;
+  keys: string[];
+  macKeys?: string[];
+  authedOnly?: boolean;
+};
+
+type Group = {
+  label: string;
+  items: Hotkey[];
+};
+
+const GROUPS: Group[] = [
+  {
+    label: "Global",
+    items: [
+      { label: "Command palette", keys: ["Ctrl", "K"], macKeys: ["⌘", "K"], authedOnly: true },
+      { label: "Dashboard", keys: ["g", "d"], authedOnly: true },
+      { label: "New document", keys: ["g", "n"], authedOnly: true },
+      { label: "Hotkeys", keys: ["?"] },
+    ],
+  },
+  {
+    label: "Reader",
+    items: [
+      { label: "View raw", keys: ["r"] },
+      { label: "Copy link", keys: ["c"] },
+      { label: "Toggle outline", keys: ["o"] },
+      { label: "Toggle width", keys: ["w"] },
+      { label: "Edit", keys: ["e"], authedOnly: true },
+    ],
+  },
+  {
+    label: "Editor",
+    items: [
+      { label: "Save", keys: ["Ctrl", "S"], macKeys: ["⌘", "S"], authedOnly: true },
+      { label: "Cancel", keys: ["Esc"], authedOnly: true },
+    ],
+  },
+  {
+    label: "Settings",
+    items: [{ label: "Back", keys: ["Esc"], authedOnly: true }],
+  },
+];
+
+export function HotkeyCheatSheet({ isAuthed }: { isAuthed: boolean }) {
+  const [open, setOpen] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  function close() {
+    setOpen(false);
+  }
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.repeat) return;
+      if (document.documentElement.dataset.cmdPaletteOpen === "true") return;
+
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+
+      if (e.key === "Escape") {
+        if (!open) return;
+        e.preventDefault();
+        close();
+        return;
+      }
+
+      if (e.key === "?" || (e.key === "/" && e.shiftKey)) {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    }
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    document.documentElement.setAttribute("data-hotkeys-open", "true");
+    const focusHandle = window.setTimeout(() => closeButtonRef.current?.focus(), 0);
+    return () => {
+      document.documentElement.removeAttribute("data-hotkeys-open");
+      window.clearTimeout(focusHandle);
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="hotkey-sheet-backdrop fixed inset-0 z-[70] flex items-start justify-center px-4 pt-[16vh]"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+      role="presentation"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Hotkeys"
+        className="w-full max-w-[520px] overflow-hidden rounded-lg border border-border bg-paper shadow-[var(--shadow-soft)]"
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+          <h2 className="text-sm font-semibold text-ink">Hotkeys</h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={close}
+            aria-label="Close hotkeys"
+            className="grid size-8 place-items-center rounded-md border border-border bg-paper text-muted transition-[border-color,color] duration-150 hover:border-ochre hover:text-ochre"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+        <div className="grid gap-3 px-4 py-4 sm:grid-cols-2">
+          {GROUPS.map((group) => {
+            const items = group.items.filter((item) => isAuthed || !item.authedOnly);
+            if (items.length === 0) return null;
+            return (
+              <section key={group.label} className="min-w-0">
+                <h3 className="mb-1.5 text-[0.625rem] font-semibold uppercase tracking-[0.12em] text-muted">
+                  {group.label}
+                </h3>
+                <div className="flex flex-col rounded-md border border-border bg-paper-warm/35">
+                  {items.map((item) => (
+                    <div
+                      key={`${group.label}:${item.label}`}
+                      className="flex min-h-9 items-center justify-between gap-3 border-b border-border px-2.5 py-1.5 last:border-b-0"
+                    >
+                      <span className="truncate text-sm text-ink">{item.label}</span>
+                      <KbdSequence item={item} />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function KbdSequence({ item }: { item: Hotkey }) {
+  return (
+    <>
+      <span data-key-mac className="flex shrink-0 items-center gap-1">
+        {(item.macKeys ?? item.keys).map((key) => (
+          <kbd
+            key={key}
+            className="rounded-[3px] border border-border bg-paper px-[5px] py-[1px] font-mono text-[0.6875rem] font-medium text-muted"
+          >
+            {key}
+          </kbd>
+        ))}
+      </span>
+      <span data-key-other className="flex shrink-0 items-center gap-1">
+        {item.keys.map((key) => (
+          <kbd
+            key={key}
+            className="rounded-[3px] border border-border bg-paper px-[5px] py-[1px] font-mono text-[0.6875rem] font-medium text-muted"
+          >
+            {key}
+          </kbd>
+        ))}
+      </span>
+    </>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-4"
+      aria-hidden="true"
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
+}

--- a/src/components/reader-shell.tsx
+++ b/src/components/reader-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition, type ReactNode } from "react";
+import { useEffect, useRef, useState, useTransition, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { OutlineRail } from "./outline-rail";
 import { ReaderToolbar } from "./reader-toolbar";
@@ -35,6 +35,15 @@ export function ReaderShell({
   const router = useRouter();
   const dashboardHref = isAuthed ? "/" : undefined;
   const [, startTransition] = useTransition();
+  const keyStateRef = useRef<{
+    rawHref: string;
+    width: Width;
+    isAuthed: boolean;
+    slug: string;
+    router: ReturnType<typeof useRouter>;
+    pickWidth: (next: Width) => void;
+    toggleOutline: () => void;
+  } | null>(null);
 
   // One-shot sync from localStorage (the unauth source of truth) after
   // hydration, since the server can't read it. Visual is already correct via
@@ -108,6 +117,18 @@ export function ReaderShell({
   }
 
   useEffect(() => {
+    keyStateRef.current = {
+      rawHref,
+      width,
+      isAuthed,
+      slug,
+      router,
+      pickWidth,
+      toggleOutline,
+    };
+  });
+
+  useEffect(() => {
     document.documentElement.setAttribute("data-scrolling", "1");
     let timer = window.setTimeout(() => {
       document.documentElement.removeAttribute("data-scrolling");
@@ -129,33 +150,40 @@ export function ReaderShell({
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
+      const state = keyStateRef.current;
+      if (!state) return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (document.documentElement.dataset.cmdPaletteOpen === "true") return;
+      if (document.documentElement.dataset.hotkeysOpen === "true") return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) return;
       switch (e.key) {
         case "r":
-          window.location.assign(rawHref);
+        case "R":
+          window.location.assign(state.rawHref);
           break;
         case "c":
+        case "C":
           void navigator.clipboard.writeText(window.location.href);
           break;
         case "w":
-          pickWidth(width === "reading" ? "wide" : "reading");
+        case "W":
+          state.pickWidth(state.width === "reading" ? "wide" : "reading");
           break;
         case "o":
-          toggleOutline();
+        case "O":
+          state.toggleOutline();
           break;
         case "e":
-          if (isAuthed) router.push(`/edit/${slug}`);
+        case "E":
+          if (state.isAuthed) state.router.push(`/edit/${state.slug}`);
           break;
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rawHref, width, hasOutline, isAuthed, slug]);
+  }, []);
 
   return (
     <main className="reader-main mx-auto flex w-full justify-center gap-6 px-6 py-10">
@@ -192,7 +220,7 @@ export function ReaderShell({
             data-outline-toggle
             onClick={toggleOutline}
             aria-label={outlineShown ? "Hide outline" : "Show outline"}
-            title={outlineShown ? "Hide outline" : "Show outline"}
+            title={outlineShown ? "Hide outline (o)" : "Show outline (o)"}
             aria-pressed={outlineShown}
             className="reader-outline-toggle grid size-8 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[background-color,border-color,color] duration-200 hover:border-ochre hover:text-ochre"
           >
@@ -204,6 +232,7 @@ export function ReaderShell({
           onWidthChange={pickWidth}
           rawHref={rawHref}
           dashboardHref={dashboardHref}
+          editHref={isAuthed ? `/edit/${slug}` : undefined}
         />
       </div>
     </main>

--- a/src/components/reader-toolbar.tsx
+++ b/src/components/reader-toolbar.tsx
@@ -10,6 +10,7 @@ type Props = {
   onWidthChange: (next: Width) => void;
   rawHref: string;
   dashboardHref?: string;
+  editHref?: string;
 };
 
 export function ReaderToolbar({
@@ -17,10 +18,12 @@ export function ReaderToolbar({
   onWidthChange,
   rawHref,
   dashboardHref,
+  editHref,
 }: Props) {
   return (
     <div className="reader-toolbar flex flex-col items-center gap-1.5">
       <WidthPill value={width} onChange={onWidthChange} />
+      {editHref && <EditButton href={editHref} />}
       <CopyLinkButton />
       <RawButton href={rawHref} />
       {dashboardHref && <DashboardButton href={dashboardHref} />}
@@ -48,7 +51,7 @@ function WidthPill({
           data-width-pill={w}
           onClick={() => onChange(w)}
           aria-label={`Width: ${w}`}
-          title={w === "reading" ? "Reading width" : "Wide width"}
+          title={w === "reading" ? "Reading width (w)" : "Wide width (w)"}
           aria-pressed={value === w}
           className="reader-toolbar__width-btn cursor-pointer border-0 bg-transparent py-1 font-mono text-[0.625rem] font-medium leading-none tracking-[0.04em] text-muted"
         >
@@ -79,7 +82,7 @@ function CopyLinkButton() {
   return (
     <ToolbarButton
       onClick={copy}
-      label={copied ? "Copied" : "Copy link"}
+      label={copied ? "Copied" : "Copy link (c)"}
       data-copied={copied ? "true" : undefined}
     >
       {copied ? <CheckIcon /> : <LinkIcon />}
@@ -90,10 +93,22 @@ function CopyLinkButton() {
 function RawButton({ href }: { href: string }) {
   return (
     <ToolbarButton
-      label="View raw"
+      label="View raw (r)"
       onClick={() => window.location.assign(href)}
     >
       <RawIcon />
+    </ToolbarButton>
+  );
+}
+
+function EditButton({ href }: { href: string }) {
+  const router = useRouter();
+  return (
+    <ToolbarButton
+      label="Edit (e)"
+      onClick={() => router.push(href)}
+    >
+      <EditIcon />
     </ToolbarButton>
   );
 }
@@ -170,6 +185,15 @@ function RawIcon() {
     <svg {...strokeProps()}>
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
       <path d="M14 2v6h6" />
+    </svg>
+  );
+}
+
+function EditIcon() {
+  return (
+    <svg {...strokeProps()}>
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z" />
     </svg>
   );
 }


### PR DESCRIPTION
Closes #38.

## Summary

- Tightens the command palette around document jumping plus global actions only.
- Adds contextual reader/editor affordances for edit and view flows.
- Adds a global ? hotkey cheat-sheet grouped by surface.
- Advertises reader hotkeys in existing toolbar tooltips.

## Verification

- pnpm lint
- pnpm test
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive hotkey reference guide accessible via `?` or Shift+/ displaying all available keyboard shortcuts
  * Added "View" button in edit mode to preview documents

* **Improvements**
  * Updated keyboard shortcut labels throughout the interface for better discoverability
  * Enhanced keyboard event handling to prevent conflicts between the hotkey guide and other interactive overlays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->