### PR TITLE
Fix reader outline and AuthKit proxy regressions

### DIFF
--- a/src/app/v/[slug]/page.tsx
+++ b/src/app/v/[slug]/page.tsx
@@ -5,7 +5,10 @@ import { isEmailAllowed } from "@/lib/access";
 import { getDocBySlug } from "@/lib/db";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { ReaderShell } from "@/components/reader-shell";
-import { parseHeadings } from "@/lib/heading-utils";
+import {
+  parseHeadings,
+  shouldAutoShowOutline,
+} from "@/lib/heading-utils";
 import { resolveReaderPrefs } from "@/lib/reader-prefs";
 
 type PageProps = {
@@ -55,20 +58,19 @@ export default async function ViewPage({ params, searchParams }: PageProps) {
   if (!doc) notFound();
 
   const headings = parseHeadings(doc.content);
-  const hasOutline = headings.filter((h) => h.level === 2).length >= 3;
+  const autoShowEligible = shouldAutoShowOutline(headings);
 
   const { user } = await withAuth();
   const isAuthed = !!user && isEmailAllowed(user.email);
   const { initialWidth, initialOutlineShown } = await resolveReaderPrefs({
     userId: isAuthed ? user!.id : null,
-    hasOutline,
+    autoShowEligible,
   });
 
   return (
     <ReaderShell
       slug={doc.slug}
       rawHref={`/api/raw/${doc.slug}`}
-      hasOutline={hasOutline}
       headings={headings}
       isAuthed={isAuthed}
       initialWidth={initialWidth}

--- a/src/components/reader-shell.tsx
+++ b/src/components/reader-shell.tsx
@@ -14,7 +14,6 @@ const OUTLINE_KEY = "md.outline.shown";
 export function ReaderShell({
   slug,
   rawHref,
-  hasOutline,
   headings,
   isAuthed,
   initialWidth,
@@ -23,7 +22,6 @@ export function ReaderShell({
 }: {
   slug: string;
   rawHref: string;
-  hasOutline: boolean;
   headings: Heading[];
   isAuthed: boolean;
   initialWidth: Width;
@@ -56,11 +54,9 @@ export function ReaderShell({
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setWidth(stored);
     }
-    if (hasOutline) {
-      const o = localStorage.getItem(OUTLINE_KEY);
-      if (o !== null) setOutlineShown(o === "true");
-    }
-  }, [isAuthed, hasOutline]);
+    const o = localStorage.getItem(OUTLINE_KEY);
+    if (o !== null) setOutlineShown(o === "true");
+  }, [isAuthed]);
 
   function applyWidthAttr(value: Width) {
     if (value === "wide") {
@@ -97,7 +93,6 @@ export function ReaderShell({
   }
 
   function toggleOutline() {
-    if (!hasOutline) return;
     const previous = outlineShown;
     const next = !outlineShown;
     setOutlineShown(next);
@@ -192,41 +187,45 @@ export function ReaderShell({
           {children}
         </article>
       </div>
-      {hasOutline && (
-        <aside
-          data-outline-aside
-          className="hidden min-[1100px]:sticky min-[1100px]:top-12 min-[1100px]:block min-[1100px]:max-w-60 min-[1100px]:shrink-0 min-[1100px]:self-start"
+      <aside
+        data-outline-aside
+        className={
+          outlineShown
+            ? "hidden min-[1100px]:sticky min-[1100px]:top-12 min-[1100px]:block min-[1100px]:max-w-60 min-[1100px]:shrink-0 min-[1100px]:self-start"
+            : "hidden"
+        }
+      >
+        <div className="pb-3 pt-1.5">
+          <span className="text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
+            On this page
+          </span>
+        </div>
+        <div
+          data-outline-scroll
+          className="max-h-[calc(100vh-8rem)] overflow-y-auto pr-1"
         >
-          <div className="pb-3 pt-1.5">
-            <span className="text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
-              On this page
-            </span>
-          </div>
-          <div
-            data-outline-scroll
-            className="max-h-[calc(100vh-8rem)] overflow-y-auto pr-1"
-          >
-            <OutlineRail headings={headings} />
-          </div>
-        </aside>
-      )}
+          <OutlineRail headings={headings} />
+        </div>
+      </aside>
       <div
         data-reader-toolbar-cluster
         className="hidden flex-col items-center gap-1.5 sm:sticky sm:top-14 sm:flex sm:shrink-0 sm:self-start"
       >
-        {hasOutline && (
-          <button
-            type="button"
-            data-outline-toggle
-            onClick={toggleOutline}
-            aria-label={outlineShown ? "Hide outline" : "Show outline"}
-            title={outlineShown ? "Hide outline (o)" : "Show outline (o)"}
-            aria-pressed={outlineShown}
-            className="reader-outline-toggle grid size-8 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[background-color,border-color,color] duration-200 hover:border-ochre hover:text-ochre"
-          >
-            <OutlineIcon />
-          </button>
-        )}
+        <button
+          type="button"
+          data-outline-toggle={outlineShown ? "true" : undefined}
+          onClick={toggleOutline}
+          aria-label={outlineShown ? "Hide outline" : "Show outline"}
+          title={outlineShown ? "Hide outline (o)" : "Show outline (o)"}
+          aria-pressed={outlineShown}
+          className={
+            outlineShown
+              ? "reader-outline-toggle grid size-8 cursor-pointer place-items-center rounded-md border border-ochre bg-ochre text-paper transition-[background-color,border-color,color] duration-200 hover:text-paper"
+              : "reader-outline-toggle grid size-8 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[background-color,border-color,color] duration-200 hover:border-ochre hover:text-ochre"
+          }
+        >
+          <OutlineIcon />
+        </button>
         <ReaderToolbar
           width={width}
           onWidthChange={pickWidth}

--- a/src/components/reader-shell.tsx
+++ b/src/components/reader-shell.tsx
@@ -189,11 +189,7 @@ export function ReaderShell({
       </div>
       <aside
         data-outline-aside
-        className={
-          outlineShown
-            ? "hidden min-[1100px]:sticky min-[1100px]:top-12 min-[1100px]:block min-[1100px]:max-w-60 min-[1100px]:shrink-0 min-[1100px]:self-start"
-            : "hidden"
-        }
+        className="hidden min-[1100px]:sticky min-[1100px]:top-12 min-[1100px]:block min-[1100px]:max-w-60 min-[1100px]:shrink-0 min-[1100px]:self-start"
       >
         <div className="pb-3 pt-1.5">
           <span className="text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
@@ -213,16 +209,12 @@ export function ReaderShell({
       >
         <button
           type="button"
-          data-outline-toggle={outlineShown ? "true" : undefined}
+          data-outline-toggle
           onClick={toggleOutline}
           aria-label={outlineShown ? "Hide outline" : "Show outline"}
           title={outlineShown ? "Hide outline (o)" : "Show outline (o)"}
           aria-pressed={outlineShown}
-          className={
-            outlineShown
-              ? "reader-outline-toggle grid size-8 cursor-pointer place-items-center rounded-md border border-ochre bg-ochre text-paper transition-[background-color,border-color,color] duration-200 hover:text-paper"
-              : "reader-outline-toggle grid size-8 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[background-color,border-color,color] duration-200 hover:border-ochre hover:text-ochre"
-          }
+          className="reader-outline-toggle grid size-8 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[background-color,border-color,color] duration-200 hover:border-ochre hover:text-ochre"
         >
           <OutlineIcon />
         </button>

--- a/src/lib/heading-utils.test.ts
+++ b/src/lib/heading-utils.test.ts
@@ -38,6 +38,21 @@ grep '^MD_API_KEY=' ~/.env
       },
     ]);
   });
+
+  it("ignores headings inside tilde fenced code blocks", () => {
+    const headings = parseHeadings(`## Before
+
+~~~text
+## Inside fence
+~~~
+
+## After`);
+
+    expect(headings).toEqual([
+      { id: "before", level: 2, text: "Before" },
+      { id: "after", level: 2, text: "After" },
+    ]);
+  });
 });
 
 describe("outline auto-show eligibility", () => {

--- a/src/lib/heading-utils.test.ts
+++ b/src/lib/heading-utils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseHeadings,
+  shouldAutoShowOutline,
+} from "./heading-utils";
+
+describe("parseHeadings", () => {
+  it("ignores headings inside fenced code blocks without losing later document headings", () => {
+    const headings = parseHeadings(`# Install
+
+\`\`\`text
+=== BEGIN SKILL.md ===
+# md-upload
+
+## Authentication
+
+\`\`\`bash
+grep '^MD_API_KEY=' ~/.env
+\`\`\`
+
+## Content source
+## Upload
+### Title
+## Delete
+
+## Notes for the installing Claude
+`);
+
+    expect(headings).toEqual([
+      { id: "content-source", level: 2, text: "Content source" },
+      { id: "upload", level: 2, text: "Upload" },
+      { id: "title", level: 3, text: "Title" },
+      { id: "delete", level: 2, text: "Delete" },
+      {
+        id: "notes-for-the-installing-claude",
+        level: 2,
+        text: "Notes for the installing Claude",
+      },
+    ]);
+  });
+});
+
+describe("outline auto-show eligibility", () => {
+  it("auto-shows for two top-level sections", () => {
+    expect(
+      shouldAutoShowOutline([
+        { id: "objective", level: 2, text: "Objective" },
+        { id: "steps", level: 2, text: "Steps" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("auto-shows for one section with enough nested structure", () => {
+    expect(
+      shouldAutoShowOutline([
+        { id: "usage", level: 2, text: "Usage" },
+        { id: "setup", level: 3, text: "Setup" },
+        { id: "auth", level: 3, text: "Auth" },
+        { id: "limits", level: 3, text: "Limits" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("keeps short single-section docs closed by default", () => {
+    expect(
+      shouldAutoShowOutline([
+        { id: "objective", level: 2, text: "Objective" },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/src/lib/heading-utils.ts
+++ b/src/lib/heading-utils.ts
@@ -17,13 +17,24 @@ export function parseHeadings(markdown: string): Heading[] {
   const lines = markdown.split("\n");
   const headings: Heading[] = [];
   const seen = new Map<string, number>();
-  let inFence = false;
+  let fence: { marker: "`" | "~"; length: number } | null = null;
   for (const line of lines) {
-    if (line.startsWith("```")) {
-      inFence = !inFence;
+    const fenceMatch = /^( {0,3})(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fenceMatch) {
+      const markerRun = fenceMatch[2];
+      const marker = markerRun[0] as "`" | "~";
+      const length = markerRun.length;
+      const rest = fenceMatch[3].trim();
+      if (!fence) {
+        fence = { marker, length };
+        continue;
+      }
+      if (marker === fence.marker && length >= fence.length && rest === "") {
+        fence = null;
+      }
       continue;
     }
-    if (inFence) continue;
+    if (fence) continue;
     const m = /^(#{2,3}) (.+?)\s*#*\s*$/.exec(line);
     if (!m) continue;
     const level = m[1].length === 2 ? 2 : 3;
@@ -36,6 +47,12 @@ export function parseHeadings(markdown: string): Heading[] {
     headings.push({ id, level, text });
   }
   return headings;
+}
+
+export function shouldAutoShowOutline(headings: Heading[]): boolean {
+  const h2Count = headings.filter((h) => h.level === 2).length;
+  const h3Count = headings.length - h2Count;
+  return h2Count >= 2 || (h2Count >= 1 && h3Count >= 3);
 }
 
 export function rehypeHeadingIds() {

--- a/src/lib/reader-prefs-flow.test.ts
+++ b/src/lib/reader-prefs-flow.test.ts
@@ -56,7 +56,7 @@ describe("unauthed reader-prefs flow contract", () => {
     expect(script).toContain("md.outline.shown");
   });
 
-  it("resolveReaderPrefsFromPrefs falls back to width=reading + outline-shown=hasOutline", () => {
+  it("resolveReaderPrefsFromPrefs falls back to width=reading + outline-shown=autoShowEligible", () => {
     expect(resolveReaderPrefsFromPrefs(null, true)).toEqual({
       initialWidth: "reading",
       initialOutlineShown: true,

--- a/src/lib/reader-prefs.test.ts
+++ b/src/lib/reader-prefs.test.ts
@@ -3,14 +3,14 @@ import { resolveReaderPrefsFromPrefs } from "./reader-prefs";
 import { DEFAULT_PREFERENCES } from "./user-preferences";
 
 describe("resolveReaderPrefsFromPrefs", () => {
-  it("falls back to reading width and shows outline when prefs are null and the doc has an outline", () => {
+  it("falls back to reading width and shows outline when prefs are null and the doc is auto-show eligible", () => {
     expect(resolveReaderPrefsFromPrefs(null, true)).toEqual({
       initialWidth: "reading",
       initialOutlineShown: true,
     });
   });
 
-  it("forces outline closed when the doc lacks one, regardless of preference", () => {
+  it("keeps outline closed by default when the doc is not auto-show eligible, regardless of preference", () => {
     expect(
       resolveReaderPrefsFromPrefs(DEFAULT_PREFERENCES, false),
     ).toEqual({ initialWidth: "reading", initialOutlineShown: false });
@@ -21,14 +21,14 @@ describe("resolveReaderPrefsFromPrefs", () => {
     expect(resolveReaderPrefsFromPrefs(prefs, true).initialWidth).toBe("wide");
   });
 
-  it("hides the outline when autoShowOutline is off, even on docs that have one", () => {
+  it("hides the outline by default when autoShowOutline is off, even on eligible docs", () => {
     const prefs = { ...DEFAULT_PREFERENCES, autoShowOutline: false };
     expect(resolveReaderPrefsFromPrefs(prefs, true).initialOutlineShown).toBe(
       false,
     );
   });
 
-  it("shows outline when autoShowOutline is on and the doc has one", () => {
+  it("shows outline by default when autoShowOutline is on and the doc is eligible", () => {
     expect(
       resolveReaderPrefsFromPrefs(DEFAULT_PREFERENCES, true).initialOutlineShown,
     ).toBe(true);

--- a/src/lib/reader-prefs.ts
+++ b/src/lib/reader-prefs.ts
@@ -11,15 +11,15 @@ export type ResolvedReaderPrefs = {
 
 /**
  * Pure resolver: given a user's prefs (or null for unauth) and whether the
- * doc has an outline (≥3 H2s, decided upstream), produce the initial reader
- * state. The ≥3 H2 gate is preserved as a quality floor — pref says "may
- * auto-show", not "always auto-show".
+ * doc is eligible to auto-show its outline by default, produce the initial
+ * reader state. Outline availability is decided upstream and remains separate:
+ * this only answers whether the available outline starts open.
  */
 export function resolveReaderPrefsFromPrefs(
   prefs: UserPreferences | null,
-  hasOutline: boolean,
+  autoShowEligible: boolean,
 ): ResolvedReaderPrefs {
-  if (!hasOutline) {
+  if (!autoShowEligible) {
     return {
       initialWidth: prefs?.defaultWidth ?? "reading",
       initialOutlineShown: false,
@@ -33,7 +33,7 @@ export function resolveReaderPrefsFromPrefs(
 
 export async function resolveReaderPrefs(args: {
   userId: string | null;
-  hasOutline: boolean;
+  autoShowEligible: boolean;
 }): Promise<ResolvedReaderPrefs> {
   let prefs: UserPreferences | null = null;
   if (args.userId) {
@@ -43,5 +43,5 @@ export async function resolveReaderPrefs(args: {
       console.warn("[reader-prefs] getUserPreferences failed:", err);
     }
   }
-  return resolveReaderPrefsFromPrefs(prefs, args.hasOutline);
+  return resolveReaderPrefsFromPrefs(prefs, args.autoShowEligible);
 }

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,45 @@
+import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  authkitProxy: () => vi.fn(),
+}));
+
+import { config } from "./proxy";
+
+function doesProxyMatch(url: string) {
+  return unstable_doesMiddlewareMatch({
+    config,
+    nextConfig: {},
+    url,
+  });
+}
+
+describe("proxy matcher", () => {
+  it("covers app routes that read AuthKit session state", () => {
+    expect(doesProxyMatch("/")).toBe(true);
+    expect(doesProxyMatch("/new")).toBe(true);
+    expect(doesProxyMatch("/v/GEnemJPK")).toBe(true);
+    expect(doesProxyMatch("/edit/GEnemJPK")).toBe(true);
+    expect(doesProxyMatch("/settings")).toBe(true);
+  });
+
+  it("covers AuthKit and server action routes outside the old allowlist", () => {
+    expect(doesProxyMatch("/auth")).toBe(true);
+    expect(doesProxyMatch("/callback")).toBe(true);
+    expect(doesProxyMatch("/settings?reader=wide")).toBe(true);
+  });
+
+  it("covers API routes that may require session auth", () => {
+    expect(doesProxyMatch("/api/list")).toBe(true);
+    expect(doesProxyMatch("/api/docs/GEnemJPK")).toBe(true);
+    expect(doesProxyMatch("/api/tokens/token-id")).toBe(true);
+  });
+
+  it("skips static assets that do not need AuthKit session headers", () => {
+    expect(doesProxyMatch("/_next/static/chunks/app.js")).toBe(false);
+    expect(doesProxyMatch("/_next/image?url=%2Flogo.png&w=64&q=75")).toBe(false);
+    expect(doesProxyMatch("/favicon.ico")).toBe(false);
+    expect(doesProxyMatch("/logo.png")).toBe(false);
+  });
+});

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,6 +1,8 @@
 import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
 import { describe, expect, it, vi } from "vitest";
 
+import nextConfig from "../next.config";
+
 vi.mock("@workos-inc/authkit-nextjs", () => ({
   authkitProxy: () => vi.fn(),
 }));
@@ -10,7 +12,7 @@ import { config } from "./proxy";
 function doesProxyMatch(url: string) {
   return unstable_doesMiddlewareMatch({
     config,
-    nextConfig: {},
+    nextConfig,
     url,
   });
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,15 +4,6 @@ export default authkitProxy();
 
 export const config = {
   matcher: [
-    "/",
-    "/new",
-    "/v/:slug*",
-    "/edit/:slug*",
-    "/settings",
-    "/api/upload",
-    "/api/docs/:slug*",
-    "/api/list",
-    "/api/tokens",
-    "/api/tokens/:id*",
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
   ],
 };


### PR DESCRIPTION
## Summary
- keep the reader outline toggle available even when the document does not auto-show an outline
- tighten heading parsing and outline auto-show defaults
- expand AuthKit proxy coverage so Server Actions and auth-backed routes receive session context

## Verification
- pnpm lint
- pnpm test
- pnpm build
- production start smoke check on localhost:3001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heading parsing to ignore content within fenced code blocks (backtick and tilde fences).

* **Improvements**
  * Enhanced outline visibility logic: the document outline now automatically shows or hides based on document structure (number of sections and subsections) rather than simple presence checks.
  * Optimized middleware routing configuration for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->