### PR TITLE
Mobile UX: bottom-sticky bar + parity for the post-palette redesign

### DIFF
--- a/docs/mobile-ux.md
+++ b/docs/mobile-ux.md
@@ -1,0 +1,174 @@
+# Mobile UX — design decisions
+
+Companion to `docs/cmd-palette-and-discoverability.md` and the post-#37
+architecture map. This doc captures the locked decisions for bringing
+the mobile experience to parity with the desktop redesign that shipped
+in #36 / #37 / #38.
+
+## Problem
+
+The desktop redesign settled on a tight three-tool nav system: cmd
+palette (find / global verbs), thin contextual toolbar (per-surface
+click affordances + tooltip-advertised hotkeys), and `?` cheat-sheet
+(hotkey learning). Mobile broke during that redesign because two of
+the three legs are keyboard-bound:
+
+- **Reader toolbar is `sm:`-gated** (`reader-shell.tsx:208`), invisible
+  below 640px. Outline toggle, width pill, edit, copy, raw, and
+  back-to-dashboard all disappear on phones — for both authed and
+  unauth viewers.
+- **Cmd palette has no tap target.** Opens via `Cmd/Ctrl+K`, the
+  `md:cmd-palette:open` event, or the programmatic `openCmdPalette()`.
+  The dashboard's `press ⌘K to navigate` chip is decorative, not a
+  button. On a phone, the palette is unreachable.
+- **Cheat-sheet (`?`) is unreachable and moot** on touch — no hotkeys
+  to learn.
+
+Net: on mobile, a logged-in user can scroll, tap into a doc, and tap
+the dashboard's `New document` link. Nothing else. An unauth viewer of
+a shared link can only scroll.
+
+## Target users
+
+- **Authed user on phone** (`<768px`). Reading docs they own, jumping
+  between docs, occasionally editing on the go. Primary case.
+- **Authed user on portrait tablet** (~768px held one-handed). Same
+  usage as phone, just larger screen.
+- **Unauth viewer on phone**. Following a shared link from chat / email.
+  Reads, maybe copies the link to share onward, maybe views raw.
+- **Authed user on landscape tablet / desktop** (`≥768px`). Untouched
+  by this work.
+
+## Core requirements
+
+### Must-have
+
+- Cmd palette must have a tap-driven entry point on every authed mobile
+  surface.
+- Reader contextual actions (edit, copy link, view raw, back to
+  dashboard) must be tap-reachable on `/v/[slug]` at `<768px`. Authed
+  variant gets all four; unauth gets copy + raw.
+- New document must be reachable from any authed surface on mobile.
+- All existing desktop behavior (`≥768px`) is preserved unchanged.
+- Touch targets meet a touch-comfortable floor (≥40px effective hit area).
+
+### Nice-to-have
+
+- Bar hides on scroll-down, reappears on scroll-up — matches iOS Safari
+  URL bar pattern, gives long-form reading the full viewport.
+- Desktop toolbar hit targets bumped from `size-8` (32px) → `size-9` (36px)
+  to soften the trackpad-and-touch hybrid case (Surface, iPad +
+  Magic Keyboard).
+
+### Out of scope
+
+- Hotkey cheat-sheet on mobile. Hidden entirely at `<768px`.
+- Width pill (R/W) and outline toggle in the mobile bar — viewport-incompatible
+  (article fills viewport regardless; outline aside renders only `≥1100px`).
+  Both remain on `/settings` Reading section as the canonical preference UI
+  and reappear on desktop where they affect the visible page.
+- The `press ⌘K` chip on the dashboard — hidden `<md:`, no keyboard.
+- A redesign of the cmd palette or hotkey vocabulary beyond the single
+  `New document` Actions addition.
+
+## Key decisions
+
+1. **Breakpoint: Tailwind `md:` (768px).**
+   `<768px` gets the mobile shell. `≥768px` keeps the desktop shell.
+   Phones and portrait tablets get touch-first chrome; landscape
+   tablets and laptops keep the existing thin vertical toolbar +
+   keyboard-first nav.
+
+2. **Mobile chrome shape: bottom-sticky bar, `<md:` only, hide-on-scroll-down.**
+   A single bar pinned to the bottom of the viewport on mobile
+   surfaces. Hides while the user scrolls down through content;
+   reappears on any scroll-up. Above `env(safe-area-inset-bottom)` to
+   avoid the iOS home-indicator gesture area. No top header. No FAB.
+   No floating action button anywhere.
+
+3. **Bar structure mirrors the palette's "same shape on every page"
+   doctrine.** Two sections, every route:
+   - **Global section (left):** `[⌕]` palette-open. Identical on every
+     authed route.
+   - **Contextual section (right):** per-surface verbs that change
+     something visible at this viewport. If the affordance is
+     meaningless on mobile (e.g. width pill, outline toggle), it does
+     not earn a slot.
+
+4. **Per-route bar contents:**
+
+   | Route | Global | Contextual |
+   |---|---|---|
+   | `/` (dashboard, authed) | `[⌕]` | `[+ new]` |
+   | `/v/[slug]` (reader, authed) | `[⌕]` | `[edit]` `[copy]` `[raw]` `[← dashboard]` |
+   | `/v/[slug]` (reader, unauth) | — | `[copy]` `[raw]` |
+   | `/edit/[slug]` | `[⌕]` | `[view]` `[cancel]` `[save]` |
+   | `/settings` | `[⌕]` | `[← dashboard]` |
+   | `/new` | `[⌕]` | `[← dashboard]` |
+
+   The unauth reader bar has no palette section because the palette
+   itself is authed-only (`showPalette = isAuthorized` in `layout.tsx:40`).
+
+5. **Cmd palette gains `New document` in the Actions section on every
+   viewport.** Same editorial test the palette already applied to
+   `Sign out`: a global verb that is useful from anywhere, with no
+   faster path on at least one surface. On mobile it is the only fast
+   path to `/new` from non-dashboard routes; on desktop it is mildly
+   redundant with `g n`. The mild redundancy is the accepted cost of
+   keeping the palette identical across viewports.
+
+6. **Width pill and outline toggle do not appear in the mobile bar.**
+   Both are pref-setting affordances whose visible effect requires
+   wider viewports. They are reachable via `/settings` Reading section
+   on mobile.
+
+7. **Hide-on-scroll behavior:** scroll-down hides the bar; any
+   scroll-up reveals it. Same UX pattern as iOS Safari's URL bar.
+   Threshold and timing match the existing reader scroll-listener in
+   `reader-shell.tsx` to avoid a second scroll listener.
+
+8. **Brand-mark stays.** The non-interactive `md.niftymonkey.dev`
+   wordmark in `src/components/brand-mark.tsx` (mounted in `layout.tsx`)
+   continues to live `fixed bottom-4 left-4` on desktop. On mobile it
+   either moves into the bar or repositions top-left at low opacity —
+   resolved during implementation, not a load-bearing decision here.
+   (Not to be confused with the removed `Watermark` popover from #36.)
+
+9. **Cheat-sheet hidden at `<md:`.** No mount, no `?` listener on
+   touch. The component stays as-is for desktop; the gating happens at
+   the layout level.
+
+## Constraints / boundaries
+
+- The palette stays authed-only. Unauth shared-link viewers do not
+  gain palette access on mobile.
+- The bar is the *only* new piece of mobile chrome. No header, no
+  drawer, no floating buttons.
+- Desktop visuals are unchanged except for the `size-8 → size-9`
+  toolbar button bump. No layout shifts, no new components rendered
+  at `≥md:`.
+- Implementation must respect `env(safe-area-inset-bottom)` so the bar
+  sits cleanly above the iOS home-indicator and the auto-collapsing
+  Safari URL bar.
+
+## Relationship to other docs
+
+- **`docs/cmd-palette-and-discoverability.md`** — load-bearing for the
+  palette's principles. The "same shape on every page" doctrine and
+  the editorial test for Actions slots both transfer directly to the
+  mobile bar.
+- **Post-#37 architecture map** (in user memory) — describes the
+  current desktop architecture this work extends.
+- **#25 (dashboard filter bar — tags + sort)** — when it ships, the
+  filter bar is dashboard-content, not bar-content. The mobile bar
+  does not gain a filter toggle; filtering remains an in-list
+  affordance.
+
+## Open questions
+
+- Exact bar height and padding. ~48–56px is the working range; final
+  number is an implementation detail, picked against real devices.
+- Brand-mark placement on mobile (in-bar vs top-left). Not blocking.
+- Whether the editor's Save button keeps its primary fill inside the
+  bar, or whether the whole bar adopts a uniform visual treatment
+  with the primary state reserved for one slot per route.

--- a/docs/mobile-ux.md
+++ b/docs/mobile-ux.md
@@ -127,11 +127,11 @@ a shared link can only scroll.
    Threshold and timing match the existing reader scroll-listener in
    `reader-shell.tsx` to avoid a second scroll listener.
 
-8. **Brand-mark stays.** The non-interactive `md.niftymonkey.dev`
-   wordmark in `src/components/brand-mark.tsx` (mounted in `layout.tsx`)
-   continues to live `fixed bottom-4 left-4` on desktop. On mobile it
-   either moves into the bar or repositions top-left at low opacity —
-   resolved during implementation, not a load-bearing decision here.
+8. **Brand-mark is desktop-only.** The non-interactive
+   `md.niftymonkey.dev` wordmark in `src/components/brand-mark.tsx`
+   remains `fixed bottom-4 left-4` on desktop and is hidden at `<md:`
+   (the bar would otherwise occlude it). Component still mounts in
+   `layout.tsx`; visibility is controlled by responsive classes.
    (Not to be confused with the removed `Watermark` popover from #36.)
 
 9. **Cheat-sheet hidden at `<md:`.** No mount, no `?` listener on

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,6 +80,24 @@
   display: none;
 }
 
+/* Mobile bar — bottom-sticky chrome at <md:. CSS owns the slide-out
+   transform so the React component only flips a data attribute. The
+   bar sits above the iOS home-indicator gesture area via safe-area
+   insets, and reserves matching bottom padding on body so route
+   content never sits behind it. */
+.mobile-bar {
+  padding-bottom: calc(env(safe-area-inset-bottom) + 0.5rem);
+  transition: transform 220ms ease-out;
+}
+.mobile-bar[data-hidden="true"] {
+  transform: translateY(110%);
+}
+@media (max-width: 767px) {
+  :root[data-mobile-bar="1"] body {
+    padding-bottom: calc(env(safe-area-inset-bottom) + 4rem);
+  }
+}
+
 .dev-theme-switcher button {
   color: var(--muted);
 }

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
 import { UploadForm } from "@/components/upload-form";
+import { MobileBar, MobileBarLink, BackGlyph } from "@/components/mobile-bar";
 
 export const metadata = {
   title: "New document",
@@ -17,6 +18,11 @@ export default async function NewDocPage() {
   return (
     <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
       <UploadForm />
+      <MobileBar palette>
+        <MobileBarLink href="/" label="Back to dashboard">
+          <BackGlyph />
+        </MobileBarLink>
+      </MobileBar>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
 import { signOutAction } from "@/lib/auth-actions";
 import { DocList } from "@/components/doc-list";
-import { MobileBar } from "@/components/mobile-bar";
+import { MobileBar, MobileBarLink, PlusGlyph } from "@/components/mobile-bar";
 
 export default async function Home() {
   const { user } = await withAuth();
@@ -82,26 +82,9 @@ export default async function Home() {
       </div>
       <DocList ownerId={user.id} />
       <MobileBar palette>
-        <Link
-          href="/new"
-          aria-label="New document"
-          className="grid size-11 cursor-pointer place-items-center rounded-md border border-ink bg-ink text-paper transition-colors hover:bg-ochre-deep hover:border-ochre-deep"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="size-[18px]"
-            aria-hidden="true"
-          >
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <line x1="5" y1="12" x2="19" y2="12" />
-          </svg>
-        </Link>
+        <MobileBarLink href="/new" label="New document" variant="primary">
+          <PlusGlyph />
+        </MobileBarLink>
       </MobileBar>
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
 import { signOutAction } from "@/lib/auth-actions";
 import { DocList } from "@/components/doc-list";
+import { MobileBar } from "@/components/mobile-bar";
 
 export default async function Home() {
   const { user } = await withAuth();
@@ -35,7 +36,7 @@ export default async function Home() {
 
   return (
     <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
-      <div className="mb-6 flex items-center gap-3">
+      <div className="mb-6 hidden items-center gap-3 md:flex">
         <span className="inline-flex items-center gap-2 font-mono text-[0.6875rem] font-medium tracking-[0.04em] text-muted">
           press
           <span className="inline-flex gap-1">
@@ -80,6 +81,28 @@ export default async function Home() {
         </Link>
       </div>
       <DocList ownerId={user.id} />
+      <MobileBar palette>
+        <Link
+          href="/new"
+          aria-label="New document"
+          className="grid size-11 cursor-pointer place-items-center rounded-md border border-ink bg-ink text-paper transition-colors hover:bg-ochre-deep hover:border-ochre-deep"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="size-[18px]"
+            aria-hidden="true"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </Link>
+      </MobileBar>
     </main>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { ReadingSection } from "./_components/reading-section";
 import { TokensSection } from "./_components/tokens-section";
 import { AccountSection } from "./_components/account-section";
 import { SettingsBackNav } from "./_components/settings-back-nav";
+import { MobileBar, MobileBarLink, BackGlyph } from "@/components/mobile-bar";
 
 export const dynamic = "force-dynamic";
 
@@ -57,6 +58,11 @@ export default async function SettingsPage() {
 
         <AccountSection email={user.email} />
       </div>
+      <MobileBar palette>
+        <MobileBarLink href="/" label="Back to dashboard">
+          <BackGlyph />
+        </MobileBarLink>
+      </MobileBar>
     </main>
   );
 }

--- a/src/components/brand-mark.tsx
+++ b/src/components/brand-mark.tsx
@@ -1,6 +1,6 @@
 export function BrandMark() {
   return (
-    <div className="brand-mark pointer-events-none fixed bottom-4 left-4 z-[5] font-mono text-[0.6875rem] font-medium tracking-[0.04em] text-muted opacity-70 sm:left-6">
+    <div className="brand-mark pointer-events-none fixed bottom-4 left-4 z-[5] hidden font-mono text-[0.6875rem] font-medium tracking-[0.04em] text-muted opacity-70 sm:left-6 md:block">
       md.niftymonkey.dev
     </div>
   );

--- a/src/components/cmd-palette.tsx
+++ b/src/components/cmd-palette.tsx
@@ -180,6 +180,15 @@ export function CmdPalette({ signOutAction }: Props) {
 
   const actions: ActionItem[] = [
     {
+      id: "new-document",
+      title: "New document",
+      icon: <PlusIcon />,
+      run: () => {
+        close();
+        router.push("/new");
+      },
+    },
+    {
       id: "open-settings",
       title: "Open settings",
       icon: <SettingsIcon />,
@@ -474,6 +483,15 @@ function SignOutIcon() {
       <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
       <polyline points="16 17 21 12 16 7" />
       <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg {...strokeProps("size-3.5")}>
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
     </svg>
   );
 }

--- a/src/components/dev-theme-switcher.tsx
+++ b/src/components/dev-theme-switcher.tsx
@@ -40,7 +40,7 @@ export function DevThemeSwitcher() {
   }
 
   return (
-    <div className="dev-theme-switcher fixed bottom-3 left-3 z-[100] flex gap-1 rounded-md border border-border bg-paper p-1 font-mono text-[0.6875rem] shadow-[var(--shadow-soft)]">
+    <div className="dev-theme-switcher fixed right-3 top-3 z-[100] flex gap-1 rounded-md border border-border bg-paper p-1 font-mono text-[0.6875rem] shadow-[var(--shadow-soft)] md:bottom-3 md:left-3 md:right-auto md:top-auto">
       {MODES.map((m) => (
         <button
           key={m}

--- a/src/components/doc-list.tsx
+++ b/src/components/doc-list.tsx
@@ -2,11 +2,12 @@ import Link from "next/link";
 import { listDocs } from "@/lib/db";
 import { DeleteButton } from "@/components/delete-button";
 import { EditLink } from "@/components/edit-link";
+import { RowKebabMenu } from "@/components/row-kebab-menu";
 
 const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
-  month: "short",
-  day: "numeric",
+  month: "2-digit",
+  day: "2-digit",
 });
 
 export async function DocList({ ownerId }: { ownerId: string }) {
@@ -37,10 +38,11 @@ export async function DocList({ ownerId }: { ownerId: string }) {
           <span className="font-mono text-xs text-muted [font-variant-numeric:tabular-nums]">
             {DATE_FORMAT.format(doc.createdAt)}
           </span>
-          <span className="flex items-center gap-1">
+          <span className="hidden items-center gap-1 md:flex">
             <EditLink slug={doc.slug} title={doc.title} />
             <DeleteButton slug={doc.slug} title={doc.title} />
           </span>
+          <RowKebabMenu slug={doc.slug} title={doc.title} />
         </li>
       ))}
     </ul>

--- a/src/components/edit-form.tsx
+++ b/src/components/edit-form.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { MobileBar } from "@/components/mobile-bar";
 
 const MAX_BYTES = 1024 * 1024;
 
@@ -165,7 +166,7 @@ export function EditForm({
         >
           {statusLabel}
         </span>
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto hidden items-center gap-2 md:flex">
           <button
             type="button"
             onClick={() => router.push(`/v/${slug}`)}
@@ -198,7 +199,76 @@ export function EditForm({
           {error}
         </p>
       )}
+      <MobileBar palette>
+        <button
+          type="button"
+          onClick={() => router.push(`/v/${slug}`)}
+          aria-label="View document"
+          className="grid size-11 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[border-color,color] duration-150 hover:border-ochre hover:text-ochre"
+        >
+          <ViewGlyph />
+        </button>
+        <button
+          type="button"
+          onClick={cancel}
+          aria-label="Cancel"
+          className="grid size-11 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[border-color,color] duration-150 hover:border-ochre hover:text-ochre"
+        >
+          <CancelGlyph />
+        </button>
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={saving || !dirty}
+          aria-label={saving ? "Saving" : "Save"}
+          className="grid size-11 cursor-pointer place-items-center rounded-md border border-ink bg-ink text-paper transition-colors duration-150 hover:bg-ochre-deep hover:border-ochre-deep disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-ink disabled:hover:border-ink"
+        >
+          <SaveGlyph />
+        </button>
+      </MobileBar>
     </div>
+  );
+}
+
+function glyphProps() {
+  return {
+    xmlns: "http://www.w3.org/2000/svg",
+    viewBox: "0 0 24 24",
+    fill: "none" as const,
+    stroke: "currentColor",
+    strokeWidth: 2,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true,
+    className: "size-[18px]",
+  };
+}
+
+function ViewGlyph() {
+  return (
+    <svg {...glyphProps()}>
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+function CancelGlyph() {
+  return (
+    <svg {...glyphProps()}>
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
+}
+
+function SaveGlyph() {
+  return (
+    <svg {...glyphProps()}>
+      <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+      <polyline points="17 21 17 13 7 13 7 21" />
+      <polyline points="7 3 7 8 15 8" />
+    </svg>
   );
 }
 

--- a/src/components/hotkey-cheat-sheet.tsx
+++ b/src/components/hotkey-cheat-sheet.tsx
@@ -78,6 +78,7 @@ export function HotkeyCheatSheet({ isAuthed }: { isAuthed: boolean }) {
       }
 
       if (e.key === "?" || (e.key === "/" && e.shiftKey)) {
+        if (window.matchMedia("(max-width: 767px)").matches) return;
         e.preventDefault();
         setOpen((v) => !v);
       }

--- a/src/components/mobile-bar.tsx
+++ b/src/components/mobile-bar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import Link from "next/link";
 import { openCmdPalette } from "./cmd-palette";
 
 const HIDE_THRESHOLD = 8;
@@ -70,6 +71,70 @@ function PaletteGlyph() {
     >
       <SearchIcon />
     </button>
+  );
+}
+
+export function MobileBarLink({
+  href,
+  label,
+  children,
+  variant = "ghost",
+}: {
+  href: string;
+  label: string;
+  children: ReactNode;
+  variant?: "ghost" | "primary";
+}) {
+  const ghost =
+    "border border-border bg-paper text-muted hover:border-ochre hover:text-ochre";
+  const primary =
+    "border border-ink bg-ink text-paper hover:bg-ochre-deep hover:border-ochre-deep";
+  return (
+    <Link
+      href={href}
+      aria-label={label}
+      className={`grid size-11 cursor-pointer place-items-center rounded-md transition-colors duration-150 ${variant === "primary" ? primary : ghost}`}
+    >
+      <span className="grid size-[18px] place-items-center">{children}</span>
+    </Link>
+  );
+}
+
+export function PlusGlyph() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className="size-[18px]"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+export function BackGlyph() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className="size-[18px]"
+    >
+      <line x1="19" y1="12" x2="5" y2="12" />
+      <polyline points="12 19 5 12 12 5" />
+    </svg>
   );
 }
 

--- a/src/components/mobile-bar.tsx
+++ b/src/components/mobile-bar.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { openCmdPalette } from "./cmd-palette";
+
+const HIDE_THRESHOLD = 8;
+const REVEAL_THRESHOLD = 4;
+const FLOOR = 64;
+
+type Props = {
+  palette?: boolean;
+  children?: ReactNode;
+};
+
+export function MobileBar({ palette = false, children }: Props) {
+  const [hidden, setHidden] = useState(false);
+  const lastY = useRef(0);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-mobile-bar", "1");
+    return () => {
+      document.documentElement.removeAttribute("data-mobile-bar");
+    };
+  }, []);
+
+  useEffect(() => {
+    lastY.current = window.scrollY;
+    function onScroll() {
+      const y = window.scrollY;
+      const dy = y - lastY.current;
+      lastY.current = y;
+      if (y < FLOOR) {
+        setHidden(false);
+        return;
+      }
+      if (dy > HIDE_THRESHOLD) setHidden(true);
+      else if (dy < -REVEAL_THRESHOLD) setHidden(false);
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const hasContextual = !!children;
+
+  return (
+    <nav
+      data-mobile-bar-nav
+      data-hidden={hidden ? "true" : undefined}
+      aria-label="Page actions"
+      className="mobile-bar fixed inset-x-0 bottom-0 z-40 flex items-center gap-1.5 border-t border-border bg-paper/95 px-3 pt-2 backdrop-blur-sm md:hidden"
+    >
+      {palette && <PaletteGlyph />}
+      {palette && hasContextual && (
+        <span aria-hidden="true" className="mx-0.5 h-6 w-px bg-border" />
+      )}
+      {hasContextual && (
+        <div className="ml-auto flex items-center gap-1.5">{children}</div>
+      )}
+    </nav>
+  );
+}
+
+function PaletteGlyph() {
+  return (
+    <button
+      type="button"
+      onClick={() => openCmdPalette()}
+      aria-label="Open command palette"
+      className="grid size-11 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[border-color,color] duration-150 hover:border-ochre hover:text-ochre"
+    >
+      <SearchIcon />
+    </button>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-[18px]"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  );
+}

--- a/src/components/reader-shell.tsx
+++ b/src/components/reader-shell.tsx
@@ -215,7 +215,7 @@ export function ReaderShell({
           aria-label={outlineShown ? "Hide outline" : "Show outline"}
           title={outlineShown ? "Hide outline (o)" : "Show outline (o)"}
           aria-pressed={outlineShown}
-          className="reader-outline-toggle grid size-8 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[background-color,border-color,color] duration-200 hover:border-ochre hover:text-ochre"
+          className="reader-outline-toggle grid size-9 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[background-color,border-color,color] duration-200 hover:border-ochre hover:text-ochre"
         >
           <OutlineIcon />
         </button>

--- a/src/components/reader-shell.tsx
+++ b/src/components/reader-shell.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState, useTransition, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { OutlineRail } from "./outline-rail";
-import { ReaderToolbar } from "./reader-toolbar";
+import { ReaderToolbar, ReaderMobileBarButtons } from "./reader-toolbar";
+import { MobileBar } from "./mobile-bar";
 import { saveReadingPrefs } from "@/app/settings/actions";
 import type { Heading } from "@/lib/heading-utils";
 import type { Width } from "@/lib/user-preferences";
@@ -205,7 +206,7 @@ export function ReaderShell({
       </aside>
       <div
         data-reader-toolbar-cluster
-        className="hidden flex-col items-center gap-1.5 sm:sticky sm:top-14 sm:flex sm:shrink-0 sm:self-start"
+        className="hidden flex-col items-center gap-1.5 md:sticky md:top-14 md:flex md:shrink-0 md:self-start"
       >
         <button
           type="button"
@@ -226,6 +227,13 @@ export function ReaderShell({
           editHref={isAuthed ? `/edit/${slug}` : undefined}
         />
       </div>
+      <MobileBar palette={isAuthed}>
+        <ReaderMobileBarButtons
+          rawHref={rawHref}
+          dashboardHref={dashboardHref}
+          editHref={isAuthed ? `/edit/${slug}` : undefined}
+        />
+      </MobileBar>
     </main>
   );
 }

--- a/src/components/reader-toolbar.tsx
+++ b/src/components/reader-toolbar.tsx
@@ -63,7 +63,7 @@ function WidthPill({
     <div
       role="group"
       aria-label="Article width"
-      className="reader-toolbar__width-pill flex w-8 flex-col overflow-hidden rounded-md border border-border bg-paper"
+      className="reader-toolbar__width-pill flex w-9 flex-col overflow-hidden rounded-md border border-border bg-paper"
     >
       {(["reading", "wide"] as const).map((w) => (
         <button
@@ -162,7 +162,7 @@ function ToolbarButton({
       onClick={onClick}
       aria-label={label}
       title={label}
-      className="reader-toolbar__btn grid size-8 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[border-color,color] duration-200 hover:border-ochre hover:text-ochre"
+      className="reader-toolbar__btn grid size-9 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[border-color,color] duration-200 hover:border-ochre hover:text-ochre"
       {...rest}
     >
       {children}

--- a/src/components/reader-toolbar.tsx
+++ b/src/components/reader-toolbar.tsx
@@ -31,6 +31,27 @@ export function ReaderToolbar({
   );
 }
 
+type MobileProps = {
+  rawHref: string;
+  dashboardHref?: string;
+  editHref?: string;
+};
+
+export function ReaderMobileBarButtons({
+  rawHref,
+  dashboardHref,
+  editHref,
+}: MobileProps) {
+  return (
+    <>
+      {editHref && <MobileEditButton href={editHref} />}
+      <MobileCopyLinkButton />
+      <MobileRawButton href={rawHref} />
+      {dashboardHref && <MobileDashboardButton href={dashboardHref} />}
+    </>
+  );
+}
+
 function WidthPill({
   value,
   onChange,
@@ -146,6 +167,90 @@ function ToolbarButton({
     >
       {children}
     </button>
+  );
+}
+
+function MobileBarButton({
+  onClick,
+  label,
+  children,
+  ...rest
+}: {
+  onClick: () => void;
+  label: string;
+  children: ReactNode;
+} & Record<string, unknown>) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className="grid size-11 cursor-pointer place-items-center rounded-md border border-border bg-paper text-muted transition-[border-color,color] duration-150 hover:border-ochre hover:text-ochre"
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+function MobileCopyLinkButton() {
+  const [copied, setCopied] = useState(false);
+  function copy() {
+    if (typeof window === "undefined") return;
+    if (!navigator.clipboard?.writeText) return;
+    void navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  }
+  return (
+    <MobileBarButton
+      onClick={copy}
+      label={copied ? "Copied" : "Copy link"}
+      data-copied={copied ? "true" : undefined}
+    >
+      <span className="grid size-[18px] place-items-center">
+        {copied ? <CheckIcon /> : <LinkIcon />}
+      </span>
+    </MobileBarButton>
+  );
+}
+
+function MobileRawButton({ href }: { href: string }) {
+  return (
+    <MobileBarButton
+      label="View raw"
+      onClick={() => window.location.assign(href)}
+    >
+      <span className="grid size-[18px] place-items-center">
+        <RawIcon />
+      </span>
+    </MobileBarButton>
+  );
+}
+
+function MobileEditButton({ href }: { href: string }) {
+  const router = useRouter();
+  return (
+    <MobileBarButton label="Edit" onClick={() => router.push(href)}>
+      <span className="grid size-[18px] place-items-center">
+        <EditIcon />
+      </span>
+    </MobileBarButton>
+  );
+}
+
+function MobileDashboardButton({ href }: { href: string }) {
+  const router = useRouter();
+  return (
+    <MobileBarButton label="Back to dashboard" onClick={() => router.push(href)}>
+      <span className="grid size-[18px] place-items-center">
+        <BackIcon />
+      </span>
+    </MobileBarButton>
   );
 }
 

--- a/src/components/row-kebab-menu.tsx
+++ b/src/components/row-kebab-menu.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+export function RowKebabMenu({ slug, title }: { slug: string; title: string }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent | TouchEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("touchstart", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("touchstart", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  async function onDelete() {
+    setOpen(false);
+    if (!window.confirm(`Delete "${title}"? This cannot be undone.`)) return;
+    let response: Response;
+    try {
+      response = await fetch(`/api/docs/${slug}`, { method: "DELETE" });
+    } catch {
+      window.alert("Network error");
+      return;
+    }
+    if (!response.ok) {
+      let message = `Delete failed (${response.status})`;
+      try {
+        const data = await response.json();
+        if (data?.error) message = data.error;
+      } catch {
+        // ignore parse failure
+      }
+      window.alert(message);
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <div ref={ref} className="relative md:hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={`Actions for ${title}`}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="grid size-9 cursor-pointer place-items-center rounded-md text-muted transition-colors hover:bg-paper hover:text-ochre"
+      >
+        <KebabIcon />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label={`Actions for ${title}`}
+          className="absolute right-0 top-full z-30 mt-1 min-w-40 overflow-hidden rounded-md border border-border bg-paper shadow-[var(--shadow-soft)]"
+        >
+          <Link
+            href={`/edit/${slug}`}
+            role="menuitem"
+            prefetch={false}
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2.5 px-3 py-2.5 text-sm text-ink transition-colors hover:bg-paper-warm"
+          >
+            <EditIcon />
+            <span>Edit</span>
+          </Link>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={onDelete}
+            className="flex w-full cursor-pointer items-center gap-2.5 border-t border-border px-3 py-2.5 text-left text-sm text-ink transition-colors hover:bg-paper-warm"
+          >
+            <DeleteIcon />
+            <span>Delete</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function strokeProps() {
+  return {
+    xmlns: "http://www.w3.org/2000/svg",
+    viewBox: "0 0 24 24",
+    fill: "none" as const,
+    stroke: "currentColor",
+    strokeWidth: 2,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true,
+    className: "size-4",
+  };
+}
+
+function KebabIcon() {
+  return (
+    <svg {...strokeProps()}>
+      <circle cx="12" cy="5" r="1" />
+      <circle cx="12" cy="12" r="1" />
+      <circle cx="12" cy="19" r="1" />
+    </svg>
+  );
+}
+
+function EditIcon() {
+  return (
+    <svg {...strokeProps()}>
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+    </svg>
+  );
+}
+
+function DeleteIcon() {
+  return (
+    <svg {...strokeProps()}>
+      <path d="M3 6h18" />
+      <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
+  );
+}

--- a/src/components/row-kebab-menu.tsx
+++ b/src/components/row-kebab-menu.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 export function RowKebabMenu({ slug, title }: { slug: string; title: string }) {
   const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [isPending, startTransition] = useTransition();
   const ref = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
@@ -30,27 +32,35 @@ export function RowKebabMenu({ slug, title }: { slug: string; title: string }) {
   }, [open]);
 
   async function onDelete() {
+    if (busy) return;
     setOpen(false);
     if (!window.confirm(`Delete "${title}"? This cannot be undone.`)) return;
-    let response: Response;
+    setBusy(true);
     try {
-      response = await fetch(`/api/docs/${slug}`, { method: "DELETE" });
-    } catch {
-      window.alert("Network error");
-      return;
-    }
-    if (!response.ok) {
-      let message = `Delete failed (${response.status})`;
+      let response: Response;
       try {
-        const data = await response.json();
-        if (data?.error) message = data.error;
+        response = await fetch(`/api/docs/${slug}`, { method: "DELETE" });
       } catch {
-        // ignore parse failure
+        window.alert("Network error");
+        return;
       }
-      window.alert(message);
-      return;
+      if (!response.ok) {
+        let message = `Delete failed (${response.status})`;
+        try {
+          const data = await response.json();
+          if (data?.error) message = data.error;
+        } catch {
+          // ignore parse failure
+        }
+        window.alert(message);
+        return;
+      }
+      startTransition(() => {
+        router.refresh();
+      });
+    } finally {
+      setBusy(false);
     }
-    router.refresh();
   }
 
   return (
@@ -85,7 +95,8 @@ export function RowKebabMenu({ slug, title }: { slug: string; title: string }) {
             type="button"
             role="menuitem"
             onClick={onDelete}
-            className="flex w-full cursor-pointer items-center gap-2.5 border-t border-border px-3 py-2.5 text-left text-sm text-ink transition-colors hover:bg-paper-warm"
+            disabled={busy || isPending}
+            className="flex w-full cursor-pointer items-center gap-2.5 border-t border-border px-3 py-2.5 text-left text-sm text-ink transition-colors hover:bg-paper-warm disabled:cursor-not-allowed disabled:opacity-50"
           >
             <DeleteIcon />
             <span>Delete</span>

--- a/src/components/row-kebab-menu.tsx
+++ b/src/components/row-kebab-menu.tsx
@@ -61,7 +61,7 @@ export function RowKebabMenu({ slug, title }: { slug: string; title: string }) {
         aria-label={`Actions for ${title}`}
         aria-expanded={open}
         aria-haspopup="menu"
-        className="grid size-9 cursor-pointer place-items-center rounded-md text-muted transition-colors hover:bg-paper hover:text-ochre"
+        className="grid h-9 w-6 cursor-pointer place-items-center rounded-md text-muted transition-colors hover:bg-paper hover:text-ochre"
       >
         <KebabIcon />
       </button>


### PR DESCRIPTION
Closes #41.

Brings the mobile experience to parity with the post-#39 desktop redesign. The desktop nav settled on cmd palette + thin contextual reader toolbar + `?` cheat-sheet — two of those three legs are keyboard-bound, and the third was `sm:`-gated, leaving mobile with no tap-driven navigation or actions.

Design decisions captured in [`docs/mobile-ux.md`](docs/mobile-ux.md).

## Summary

- **New `MobileBar` component** — bottom-sticky, `<md:` only, hides on scroll-down / shows on scroll-up (iOS Safari pattern), respects `env(safe-area-inset-bottom)`. Two-section structure: global `[⌕]` palette glyph (when authed) + per-route contextual slots.
- **Per-route bar contents:**
  - `/` (dashboard, authed): `[⌕]` `[+ new]`
  - `/v/[slug]` (reader, authed): `[⌕]` `[edit]` `[copy]` `[raw]` `[← back]`
  - `/v/[slug]` (reader, unauth): `[copy]` `[raw]`
  - `/edit/[slug]`: `[⌕]` `[view]` `[cancel]` `[save]`
  - `/settings`: `[⌕]` `[← back]`
  - `/new`: `[⌕]` `[← back]`
- **Cmd palette gains `New document` action** on every viewport. Mild redundancy with `g n` on desktop is the accepted cost of palette consistency across viewports — same editorial test the palette already applied to `Sign out`.
- **Reader toolbar** (`reader-toolbar.tsx` + `reader-shell.tsx`): existing `sm:flex` cluster moved to `md:flex` (gated to ≥768px). Outline toggle and width pill stay desktop-only — both are pref-setters whose visible effect requires wider viewports; both remain reachable on `/settings` Reading section.
- **Hotkey cheat-sheet (`?`)** bails at `<md:` — no hotkeys to learn on touch.
- **Dashboard rows** (`<md:` only): Edit/Delete inline buttons replaced by a trailing kebab `⋮` popover with Edit + Delete entries. Closes on outside-tap or Esc.
- **Date format**: `MM/DD/YYYY` with forward slashes (e.g., `07/26/2024`) globally, replacing the previous `Mon DD, YYYY` form. Saves horizontal space on narrow viewports.
- **Desktop toolbar bump**: `size-8` → `size-9` for trackpad-and-touch hybrid devices (Surface, iPad + Magic Keyboard).
- **Brand-mark** hidden at `<md:` (would otherwise be occluded by the bar).
- **Dev theme switcher** repositioned to top-right at `<md:` (bottom-left at `≥md:`) so it's reachable while testing without overlapping the bar.

## Notes for review

- The bar is rendered per-route rather than mounted globally in `layout.tsx`, so pre-login surfaces (`/auth`, `/callback`, `/` not-authorized fallback) get no bar.
- `:root[data-mobile-bar="1"]` is set when a `MobileBar` mounts; the `body { padding-bottom: ... }` rule that compensates for the bar's height is gated to `@media (max-width: 767px)` so it has no effect on desktop.
- 95 tests still pass, lint clean, typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sticky bottom mobile navigation bar with context-aware actions across all pages
  * Mobile-optimized document list with dropdown action menus
  * Mobile reader toolbar with simplified icon-based controls
  * Added "New document" action to command palette

* **Documentation**
  * Added mobile UX design specifications

* **Style**
  * Responsive breakpoint adjustments for improved mobile layout visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->