### PR TITLE
Render YAML frontmatter as a quiet disclosure

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -312,6 +312,115 @@ button.cmd-palette-row:hover:not([data-selected="true"]) {
   transition: none !important;
 }
 
+/* ==================== Frontmatter disclosure ====================
+   Native <details> sitting at the top of the rendered article. Quiet by
+   default — one-line summary above the H1; expands to a definition list.
+   Lives inside `.prose`, so selectors are scoped under `.prose` to win
+   over the typography plugin's defaults for details/dl/dt/dd. */
+.prose .frontmatter {
+  margin: 0 0 1.4em;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--paper-warm) 60%, transparent);
+  overflow: hidden;
+}
+
+.prose .frontmatter > .frontmatter__summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  margin: 0;
+}
+
+.prose .frontmatter > .frontmatter__summary::-webkit-details-marker {
+  display: none;
+}
+
+.frontmatter__chev {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  color: var(--muted);
+  transition: transform 180ms ease-out;
+}
+
+.prose .frontmatter[open] > .frontmatter__summary .frontmatter__chev {
+  transform: rotate(90deg);
+}
+
+.frontmatter__label {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.frontmatter__preview {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.frontmatter__preview-key {
+  color: var(--muted);
+}
+
+.frontmatter__count {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.625rem;
+  color: var(--muted);
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--paper);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.prose .frontmatter__body {
+  padding: 4px 16px 14px;
+  border-top: 1px solid var(--border);
+}
+
+.prose .frontmatter__dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 18px;
+  row-gap: 8px;
+  margin: 12px 0 0;
+  padding: 0;
+}
+
+.prose .frontmatter__dt {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.6875rem;
+  color: var(--muted);
+  line-height: 1.55;
+  margin: 0;
+  font-weight: 500;
+}
+
+.prose .frontmatter__dd {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: var(--ink);
+  line-height: 1.55;
+  margin: 0;
+  word-break: break-word;
+}
+
 /* ==================== /settings ==================== */
 .settings {
   position: relative;

--- a/src/app/v/[slug]/page.tsx
+++ b/src/app/v/[slug]/page.tsx
@@ -4,11 +4,13 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
 import { getDocBySlug } from "@/lib/db";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
+import { FrontmatterDisclosure } from "@/components/frontmatter-disclosure";
 import { ReaderShell } from "@/components/reader-shell";
 import {
   parseHeadings,
   shouldAutoShowOutline,
 } from "@/lib/heading-utils";
+import { parseFrontmatter } from "@/lib/frontmatter";
 import { resolveReaderPrefs } from "@/lib/reader-prefs";
 
 type PageProps = {
@@ -57,7 +59,8 @@ export default async function ViewPage({ params, searchParams }: PageProps) {
   const doc = await getDocBySlug(slug);
   if (!doc) notFound();
 
-  const headings = parseHeadings(doc.content);
+  const { fields: frontmatterFields, body } = parseFrontmatter(doc.content);
+  const headings = parseHeadings(body);
   const autoShowEligible = shouldAutoShowOutline(headings);
 
   const { user } = await withAuth();
@@ -76,7 +79,8 @@ export default async function ViewPage({ params, searchParams }: PageProps) {
       initialWidth={initialWidth}
       initialOutlineShown={initialOutlineShown}
     >
-      <MarkdownRenderer content={doc.content} />
+      <FrontmatterDisclosure fields={frontmatterFields} />
+      <MarkdownRenderer content={body} />
     </ReaderShell>
   );
 }

--- a/src/components/frontmatter-disclosure.tsx
+++ b/src/components/frontmatter-disclosure.tsx
@@ -1,0 +1,48 @@
+import { Fragment } from "react";
+import type { FrontmatterField } from "@/lib/frontmatter";
+
+export function FrontmatterDisclosure({ fields }: { fields: FrontmatterField[] }) {
+  if (fields.length === 0) return null;
+
+  const [first, ...rest] = fields;
+  const remaining = rest.length;
+
+  return (
+    <details className="frontmatter">
+      <summary className="frontmatter__summary">
+        <svg
+          className="frontmatter__chev"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M4 2.5l3.5 3.5L4 9.5" />
+        </svg>
+        <span className="frontmatter__label">Frontmatter</span>
+        <span className="frontmatter__preview">
+          <span className="frontmatter__preview-key">{first.key}:</span>{" "}
+          {first.value}
+        </span>
+        {remaining > 0 && (
+          <span className="frontmatter__count">
+            +{remaining} field{remaining === 1 ? "" : "s"}
+          </span>
+        )}
+      </summary>
+      <div className="frontmatter__body">
+        <dl className="frontmatter__dl">
+          {fields.map((field) => (
+            <Fragment key={field.key}>
+              <dt className="frontmatter__dt">{field.key}</dt>
+              <dd className="frontmatter__dd">{field.value}</dd>
+            </Fragment>
+          ))}
+        </dl>
+      </div>
+    </details>
+  );
+}

--- a/src/components/frontmatter-disclosure.tsx
+++ b/src/components/frontmatter-disclosure.tsx
@@ -35,8 +35,8 @@ export function FrontmatterDisclosure({ fields }: { fields: FrontmatterField[] }
       </summary>
       <div className="frontmatter__body">
         <dl className="frontmatter__dl">
-          {fields.map((field) => (
-            <Fragment key={field.key}>
+          {fields.map((field, index) => (
+            <Fragment key={`${field.key}-${index}`}>
               <dt className="frontmatter__dt">{field.key}</dt>
               <dd className="frontmatter__dd">{field.value}</dd>
             </Fragment>

--- a/src/components/reader-shell.tsx
+++ b/src/components/reader-shell.tsx
@@ -190,9 +190,9 @@ export function ReaderShell({
       </div>
       <aside
         data-outline-aside
-        className="hidden min-[1100px]:sticky min-[1100px]:top-12 min-[1100px]:block min-[1100px]:max-w-60 min-[1100px]:shrink-0 min-[1100px]:self-start"
+        className="hidden min-[1100px]:sticky min-[1100px]:top-10 min-[1100px]:block min-[1100px]:max-w-60 min-[1100px]:shrink-0 min-[1100px]:self-start"
       >
-        <div className="pb-3 pt-1.5">
+        <div className="pb-3">
           <span className="text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
             On this page
           </span>
@@ -206,7 +206,7 @@ export function ReaderShell({
       </aside>
       <div
         data-reader-toolbar-cluster
-        className="hidden flex-col items-center gap-1.5 md:sticky md:top-14 md:flex md:shrink-0 md:self-start"
+        className="hidden flex-col items-center gap-1.5 md:sticky md:top-10 md:flex md:shrink-0 md:self-start"
       >
         <button
           type="button"

--- a/src/lib/frontmatter.test.ts
+++ b/src/lib/frontmatter.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "./frontmatter";
+
+describe("parseFrontmatter", () => {
+  it("returns no fields and the original body when no frontmatter is present", () => {
+    const result = parseFrontmatter("# Hello\n\nbody text\n");
+    expect(result.fields).toEqual([]);
+    expect(result.body).toBe("# Hello\n\nbody text\n");
+  });
+
+  it("extracts simple key/value pairs and returns the stripped body", () => {
+    const input = "---\nname: foo\ndescription: bar\n---\n# Heading\n\nBody.";
+    const result = parseFrontmatter(input);
+    expect(result.fields).toEqual([
+      { key: "name", value: "foo" },
+      { key: "description", value: "bar" },
+    ]);
+    expect(result.body).toBe("# Heading\n\nBody.");
+  });
+
+  it("preserves arbitrary key names including hyphens", () => {
+    const result = parseFrontmatter("---\nallowed-tools: Read, Grep, Glob\n---\nbody");
+    expect(result.fields).toEqual([{ key: "allowed-tools", value: "Read, Grep, Glob" }]);
+  });
+
+  it("strips matching surrounding quotes from values", () => {
+    const result = parseFrontmatter('---\ntitle: "Quoted"\nname: \'single\'\n---\nbody');
+    expect(result.fields).toEqual([
+      { key: "title", value: "Quoted" },
+      { key: "name", value: "single" },
+    ]);
+  });
+
+  it("joins continuation lines into a single value", () => {
+    const input = "---\ndescription: line one\n  line two\n  line three\nname: foo\n---\nbody";
+    const result = parseFrontmatter(input);
+    expect(result.fields).toEqual([
+      { key: "description", value: "line one line two line three" },
+      { key: "name", value: "foo" },
+    ]);
+  });
+
+  it("handles a value-less key followed by an indented continuation", () => {
+    const input = "---\ndescription:\n  multi-line value\n---\nbody";
+    const result = parseFrontmatter(input);
+    expect(result.fields).toEqual([{ key: "description", value: "multi-line value" }]);
+  });
+
+  it("returns the original content when the closing fence is missing", () => {
+    const input = "---\nname: foo\n# Heading\nbody";
+    const result = parseFrontmatter(input);
+    expect(result.fields).toEqual([]);
+    expect(result.body).toBe(input);
+  });
+
+  it("ignores blank lines inside the frontmatter block", () => {
+    const result = parseFrontmatter("---\nname: foo\n\ndescription: bar\n---\nbody");
+    expect(result.fields).toEqual([
+      { key: "name", value: "foo" },
+      { key: "description", value: "bar" },
+    ]);
+  });
+
+  it("preserves CRLF line endings in the body", () => {
+    const input = "---\r\nname: foo\r\n---\r\n# Heading\r\nbody\r\n";
+    const result = parseFrontmatter(input);
+    expect(result.fields).toEqual([{ key: "name", value: "foo" }]);
+    expect(result.body).toBe("# Heading\r\nbody\r\n");
+  });
+
+  it("treats empty frontmatter as no fields and an empty body", () => {
+    const result = parseFrontmatter("---\n---\nbody");
+    expect(result.fields).toEqual([]);
+    expect(result.body).toBe("body");
+  });
+
+  it("does not treat a thematic break in the body as a frontmatter fence", () => {
+    const input = "Intro.\n\n---\n\nMore body.";
+    const result = parseFrontmatter(input);
+    expect(result.fields).toEqual([]);
+    expect(result.body).toBe(input);
+  });
+});

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,0 +1,74 @@
+export type FrontmatterField = { key: string; value: string };
+
+export type ParsedFrontmatter = {
+  fields: FrontmatterField[];
+  body: string;
+};
+
+const FRONTMATTER_RE = /^---\r?\n(?:([\s\S]*?)\r?\n)?---(?:\r?\n|$)/;
+
+/**
+ * Extracts a YAML-ish frontmatter block from the start of a markdown
+ * document. Returns the parsed key/value pairs and the body without the
+ * fenced block. If no closing fence is found, treats the document as
+ * having no frontmatter and returns the original content unchanged.
+ *
+ * Intentionally minimal: handles `key: value` lines (including continuation
+ * lines indented under a key), strips surrounding matching quotes, and
+ * preserves arbitrary key names. Doesn't try to parse nested objects,
+ * arrays-as-blocks, or anchors — those are vanishingly rare in the
+ * skill/agent/prompt files this app actually receives, and the worst case
+ * is a verbatim string in the rendered disclosure.
+ */
+export function parseFrontmatter(content: string): ParsedFrontmatter {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return { fields: [], body: content };
+
+  const yaml = match[1] ?? "";
+  const body = content.slice(match[0].length);
+  const fields: FrontmatterField[] = [];
+
+  let currentKey: string | null = null;
+  let currentParts: string[] = [];
+
+  function flush() {
+    if (currentKey === null) return;
+    const value = stripQuotes(currentParts.join(" ").trim());
+    fields.push({ key: currentKey, value });
+    currentKey = null;
+    currentParts = [];
+  }
+
+  for (const line of yaml.split(/\r?\n/)) {
+    if (line.trim() === "") continue;
+
+    if (/^\s/.test(line) && currentKey !== null) {
+      currentParts.push(line.trim());
+      continue;
+    }
+
+    const colon = line.indexOf(":");
+    if (colon === -1) {
+      if (currentKey !== null) currentParts.push(line.trim());
+      continue;
+    }
+
+    flush();
+    currentKey = line.slice(0, colon).trim();
+    const after = line.slice(colon + 1).trim();
+    if (after) currentParts.push(after);
+  }
+  flush();
+
+  return { fields, body };
+}
+
+function stripQuotes(value: string): string {
+  if (value.length < 2) return value;
+  const first = value[0];
+  const last = value[value.length - 1];
+  if ((first === '"' || first === "'") && first === last) {
+    return value.slice(1, -1);
+  }
+  return value;
+}


### PR DESCRIPTION
Closes #43.

## Summary

- New `parseFrontmatter` util extracts the leading `---`-fenced block from a markdown document; returns the parsed key/value pairs plus the body with the block stripped.
- New `<FrontmatterDisclosure>` server component renders a native `<details>` above the article: collapsed by default with a one-line preview (`name: <value>` + `+N fields` count), expands to a `dl` of all keys/values.
- The reader page strips frontmatter before parsing headings and before passing content to `MarkdownRenderer`, so the outline and the body render against just the prose.
- Sticky tops on the outline aside (`top-12`) and reader toolbar cluster (`top-14`) brought down to `top-10` so the side chrome's top edge aligns with the article's first-content top edge — true for both H1-leading docs and frontmatter-leading docs.

## Notes

- Schema-agnostic: the parser handles `key: value` lines (including indented continuation lines) and arbitrary key names. It doesn't try to handle nested objects/arrays or anchors — vanishingly rare in skill/agent/prompt files, and the worst case is a verbatim string in the rendered disclosure.
- No client JS needed for open/close — it's a native `<details>` element. Safe in the SSR'd reader.
- Unknown extras just appear as additional `dt`/`dd` rows; nothing about the rendering is coupled to a specific frontmatter shape.

11 new unit tests cover empty frontmatter, missing closing fence, CRLF endings, quoted values, continuation lines, and the body-thematic-break edge case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible frontmatter section that displays article metadata as expandable key-value pairs.

* **Style**
  * Added styling for the frontmatter disclosure section with custom chevron animations and definition list layout.
  * Adjusted sidebar outline spacing and positioning.

* **Tests**
  * Added comprehensive test coverage for frontmatter parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->