### PR TITLE
Document revision history with restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn-error.log*
 
 # operator-only Claude context (gitignored — stays on the operator's machine)
 CLAUDE.local.md
+continue.md
 
 # impeccable skill files (re-pull from upstream; PRODUCT.md and DESIGN.md stay tracked)
 /.claude/skills/impeccable/

--- a/docs/architecture/ai-first-api.md
+++ b/docs/architecture/ai-first-api.md
@@ -75,7 +75,7 @@ The `source` enum (defined in #45): `'manual' | 'cli' | 'agent' | 'restore'`. Th
 ### Phase 2 — Quality of life
 - `If-Match: <version>` enforcement on `/edits`.
 - `dryRun: true` on `/edits` — uses MatchResolver alone, no write.
-- `POST /api/agent/docs/<slug>/revisions` (list), `POST /api/agent/docs/<slug>/restore`.
+- `GET /api/agent/docs/<slug>/revisions` (list), `POST /api/agent/docs/<slug>/restore`.
 - `SectionAddresser` ships, unlocking `replaceSection` ops.
 
 ### Phase 3 — Multi-doc leverage

--- a/docs/architecture/ai-first-api.md
+++ b/docs/architecture/ai-first-api.md
@@ -1,0 +1,95 @@
+# AI-first API for md.niftymonkey.dev
+
+Architect-deep output, captured 2026-05-04. Ad-hoc design conversation, saved at the user's request so the next session can resume from this exact state. Not yet a PRD or plan — module shapes and phasing only.
+
+## Origin and intent
+
+Two needs drove the original app:
+
+1. Share markdown easily and have it render nicely outside the IDE.
+2. Let an AI coding agent put markdown directly into the app and edit it as needed.
+
+The shipped v1 ended up CLI- and script-friendly as a side benefit, and the user wants to keep that. The new work is **additive**: a parallel API surface designed for AI agents to read/edit/delete markdown as fluidly as they edit local files. The existing `/api/*` surface stays untouched.
+
+## What "AI-first" actually means here
+
+Three properties separate an AI-first surface from a CLI-friendly one. Bake these in or you'll end up with the existing API wearing a hat:
+
+1. **Targeted mutation, not full-doc replacement.** Agents already think in `Edit` semantics — `old_string`/`new_string` with uniqueness or `replace_all`. The API contract should be the same shape so the agent's mental model and the wire format are isomorphic.
+2. **Self-describing failure.** A 409 that says *"matched 4 times at lines 47, 112, 188, 256"* lets the agent fix and retry without re-reading the doc. CLI users tolerate vague errors; agents waste context on them.
+3. **Recoverability is a contract, not a feature.** Agents make confident batch edits. The API must guarantee an undo path, or the first bad batch destroys work silently.
+
+The existing `/api/*` surface is a fine CLI/scripting API. Don't change it. Mount the new surface at `/api/agent/*` — different namespace, different contract, same auth.
+
+## Modules
+
+Five survive the deletion test for AI-first work specifically. One candidate (a generic concurrency-check helper) didn't and is inlined until 3+ mutating endpoints exist.
+
+### OperationApplier *(pure, in-process)*
+- **Interface:** `apply(content, ops[]) → {content, perOpResults} | {failedAt, error, partialResults}`
+- **What it hides:** ambiguity detection, line-shift bookkeeping, atomic rollback, the resolution rule (*line-addressed ops resolve against the batch-start snapshot; string-addressed ops resolve against running content*).
+- **Leverage:** every mutating verb — single edit, batch, dry-run, future section-replace — calls this one function.
+- **Locality:** all edit semantics, including the subtle ones, land in one file with one test file.
+
+### MatchResolver *(pure, in-process)*
+- **Interface:** `findMatches(content, query, opts) → Match[]` with line/column/context.
+- **What it hides:** ambiguity classification (zero/one/many) and the structured preview lines that ship in error responses.
+- **Leverage:** OperationApplier *and* the dry-run path both consume it. Two real callers — earns its seam.
+
+### EditOpSchema *(types)*
+- Discriminated union: `replace`, `insertAfterLine`, `insertBeforeLine`, `deleteLineRange`, `replaceLineRange`. Phase-2 adds `replaceSection`.
+- **Why a module:** the same type is the request body, the applier input, and the test fixture. Defining it once anchors the contract.
+
+### SectionAddresser *(in-process, deferred to phase 2)*
+- **Interface:** `resolveSection(content, headingPath) → {fromLine, toLine}`.
+- **What it hides:** markdown AST work (heading levels, sibling boundaries, edge cases like duplicate headings).
+- **Leverage:** unlocks `replace_section`, the most natural edit unit for prose. Don't ship it in phase 1 — phase-1 string+line ops cover 80% and SectionAddresser earns more depth once real usage points at the gaps.
+
+### AgentEndpoints *(HTTP layer, namespaced at `/api/agent/*`)*
+- **Interface:** the verbs below. Every handler is a thin wrapper: parse → call applier → call `DocMutationPath.writeDocContent` (from #45) → return typed result or structured 409.
+- **What it hides:** auth re-use (the existing `requireAuth` works unchanged), JSON ↔ EditOp marshaling. Transaction shape and revision-recording are owned by `DocMutationPath`, not duplicated here.
+- **Locality:** new wire shapes never touch the existing handlers.
+
+No category-3 or category-4 dependencies surfaced. **No external ports.** Tests cross the HTTP boundary against real Postgres and the real applier.
+
+## Dependencies from #45 (Document revision history)
+
+Two modules ship in #45 and are reused here. Full design lives in `docs/architecture/revision-history.md`.
+
+- **`DocMutationPath`** — the chokepoint every content write flows through. Signature: `writeDocContent({docId, newContent, summary, source, ownerId}) → {version}`. The agent edit handler calls it with `source: 'agent'`. Revision recording, diff stats, and transaction boundary are all inside.
+- **`RevisionLog`** — owns `doc_revisions`. The agent surface doesn't call it directly; it goes through `DocMutationPath`.
+
+The `source` enum (defined in #45): `'manual' | 'cli' | 'agent' | 'restore'`. The `'agent'` value is reserved for this surface — added to the enum in #45 so #46 doesn't need a schema migration.
+
+## Phased path
+
+> **Prerequisite:** issue #45 (Document revision history with restore). Ships the `doc_revisions` table, `RevisionLog` module, `DocMutationPath` chokepoint, `DiffStats` utility, history API verbs, and history UI before this work begins. The AI-first surface inherits all of it through a single `DocMutationPath.writeDocContent(..., source: 'agent')` call from the new edit handler.
+
+### Phase 1 — Minimum AI-first surface
+- `EditOpSchema` + `MatchResolver` + `OperationApplier` as in-process modules. Fully unit-tested with zero HTTP.
+- `POST /api/agent/docs/<slug>/edits` — body `{ops: [...]}`, atomic, structured errors with line previews. Handler runs `OperationApplier.apply(...)` to compute new content, then calls `DocMutationPath.writeDocContent({source: 'agent', summary, ...})` (module shipped in #45). Every agent edit flows through the same chokepoint as manual edits and is recorded automatically.
+- `GET /api/agent/docs/<slug>` — JSON `{content, version, updatedAt}`.
+- `POST /api/agent/docs` — create (mirror of `/api/upload`, JSON-shaped, lives in the agent namespace for surface symmetry).
+- Update `~/.claude/skills/md-upload/SKILL.md` to teach the edit verb. (Or split into a sibling `md-edit` skill — leans toward separate so each skill stays single-purpose and triggers cleanly.)
+
+### Phase 2 — Quality of life
+- `If-Match: <version>` enforcement on `/edits`.
+- `dryRun: true` on `/edits` — uses MatchResolver alone, no write.
+- `POST /api/agent/docs/<slug>/revisions` (list), `POST /api/agent/docs/<slug>/restore`.
+- `SectionAddresser` ships, unlocking `replaceSection` ops.
+
+### Phase 3 — Multi-doc leverage
+- `POST /api/agent/edits` — cross-doc batch, per-doc atomic.
+- `GET /api/agent/search?q=...` — owner-scoped grep across all docs, returning slug + match contexts.
+- Skill consolidation if md-upload + md-edit both feel cramped.
+
+## What this gets us
+
+- **Existing CLI/scripting consumers untouched.** `/api/*` keeps last-write-wins semantics; nothing breaks.
+- **Agents get a surface shaped like their tools.** `Edit`-style ops, structured ambiguity errors, version-aware reads. The skill is the handshake — when an agent sees `md-edit`'s SKILL.md in context, it inherits the calling pattern.
+- **Recoverability lands first**, so the moment the new mutation verb exists, every write is reversible — including writes through the old API.
+- **One engine, two surfaces.** OperationApplier serves `/api/agent/edits` today and could back a future `/api/edits` v2 if the CLI surface ever wants to converge.
+
+## Open thread
+
+User signaled they want to dig into "a different facet of this" next. Resume from the end of this doc — no decisions are locked yet, no PRD has been drafted, no issues have been filed. Phasing above is a recommendation, not a commitment.

--- a/docs/architecture/revision-history.md
+++ b/docs/architecture/revision-history.md
@@ -20,7 +20,7 @@ Four survive the deletion test. Several candidates collapsed into helpers or van
 
 ### RevisionLog *(local-substitutable: Postgres)*
 
-- **Interface:** `record({docId, content, prevContent, summary, source, ownerId}) → {externalId, createdAt}`, `list(docId, {limit, cursor}) → {revisions, nextCursor}`, `get(docId, externalId) → Revision | null`.
+- **Interface:** `record({docId, prevContent, nextContent, summary, source, ownerId}, runner?) → {externalId, createdAt}`, `list(docId, {limit, cursor}) → {revisions, nextCursor}`, `get(docId, externalId) → Revision | null`, `countByDoc(docIds[]) → Record<docId, number>`. `prevContent` is what's stored in the row (model B); `nextContent` is used only to compute byte deltas via `DiffStats`. Optional `runner` lets the caller pass a transactional client.
 - **What it hides:** the `doc_revisions` schema, retention cap (last 50 per doc, prune on insert), ordering, external-ID generation, the `DiffStats` call that computes byte deltas at write time.
 - **Why it doesn't own restore:** Shape A (RevisionLog.restore) would force this module to write into the `docs` table, crossing the boundary it's supposed to own. Shape B (caller-orchestrated) keeps RevisionLog scoped to one table; restore is just `RevisionLog.get(...)` followed by `DocMutationPath.writeDocContent(..., source: 'restore')`.
 - **Leverage:** the only reader/writer of `doc_revisions`. Tests stay scoped to one table.
@@ -34,9 +34,9 @@ Four survive the deletion test. Several candidates collapsed into helpers or van
 
 - **What it hides:** route layout, mobile layout, restore-confirm UX.
 - **Surface:**
-  - `/dashboard/docs/<slug>/revisions` — list panel
-  - `/dashboard/docs/<slug>/revisions/<id>` — view a single revision read-only
-- **Reuse:** the markdown rendering component used by `/v/<slug>` is reused here, but the route is new and authed. The public `/v/<slug>` does not gain a `?rev=` parameter — history would leak to anyone with the slug.
+  - `/edit/<slug>/revisions` — list panel
+  - `/edit/<slug>/revisions/<id>` — view a single revision read-only
+- **Reuse:** the markdown rendering pipeline used by `/v/<slug>` (`parseFrontmatter` + `FrontmatterDisclosure` + `MarkdownRenderer`) is reused here, but the route is new and authed. The public `/v/<slug>` does not gain a `?rev=` parameter — history would leak to anyone with the slug.
 - **Restore:** action triggers a confirm UI, then `POST /api/docs/<slug>/restore`.
 
 ## Schema (`doc_revisions`)

--- a/docs/architecture/revision-history.md
+++ b/docs/architecture/revision-history.md
@@ -1,0 +1,121 @@
+# Document revision history
+
+Architect-deep output for issue #45. Captured 2026-05-05. Implementation reference for the revision-history feature: schema, modules, endpoints, UI shape, and the explicit out-of-scope items.
+
+## Goal
+
+Every successful content mutation to a document is recoverable. The same data feeds an authed history UI in the dashboard *and* (later, via #46) agent-driven edits — both flow through the same chokepoint and land in the same history.
+
+## Modules
+
+Four survive the deletion test. Several candidates collapsed into helpers or vanished as one-caller inlines.
+
+### DocMutationPath *(the chokepoint)*
+
+- **Interface:** `writeDocContent({docId, newContent, summary, source, ownerId}) → {version}`. Reads current content, writes new content, calls `RevisionLog.record(...)`, all in a single transaction.
+- **What it hides:** transaction boundary, the "snapshot before write" step, source-tagging of every mutation, the diff-stats call.
+- **Leverage:** PATCH calls it. `/restore` calls it. `/api/agent/edits` (#46) calls it. The "every mutation snapshots" property is structural, not vigilant. No mutating endpoint can forget to record a revision because there is no other code path that touches `docs.content`.
+- **Locality:** if snapshotting policy ever changes (async backups, hooks, conditional skips), one file moves.
+- **Why it's a module:** without it, every mutating handler inlines the same five steps (read prev → diff → update docs row → record revision → return version). One caller today; three known future callers. The deletion test concentrates here.
+
+### RevisionLog *(local-substitutable: Postgres)*
+
+- **Interface:** `record({docId, content, prevContent, summary, source, ownerId}) → {externalId, createdAt}`, `list(docId, {limit, cursor}) → {revisions, nextCursor}`, `get(docId, externalId) → Revision | null`.
+- **What it hides:** the `doc_revisions` schema, retention cap (last 50 per doc, prune on insert), ordering, external-ID generation, the `DiffStats` call that computes byte deltas at write time.
+- **Why it doesn't own restore:** Shape A (RevisionLog.restore) would force this module to write into the `docs` table, crossing the boundary it's supposed to own. Shape B (caller-orchestrated) keeps RevisionLog scoped to one table; restore is just `RevisionLog.get(...)` followed by `DocMutationPath.writeDocContent(..., source: 'restore')`.
+- **Leverage:** the only reader/writer of `doc_revisions`. Tests stay scoped to one table.
+
+### DiffStats *(pure, in-process)*
+
+- **Interface:** `computeDiff(prev, next) → {bytesAdded, bytesRemoved}`.
+- **Why a module:** real diff, not length subtraction. Used inside `RevisionLog.record` so the UI gets `+412 / −88` badges without rehydrating both contents. Earns extraction because the impl is non-trivial enough that test surface = one pure function.
+
+### HistoryUI *(authed dashboard surface)*
+
+- **What it hides:** route layout, mobile layout, restore-confirm UX.
+- **Surface:**
+  - `/dashboard/docs/<slug>/revisions` — list panel
+  - `/dashboard/docs/<slug>/revisions/<id>` — view a single revision read-only
+- **Reuse:** the markdown rendering component used by `/v/<slug>` is reused here, but the route is new and authed. The public `/v/<slug>` does not gain a `?rev=` parameter — history would leak to anyone with the slug.
+- **Restore:** action triggers a confirm UI, then `POST /api/docs/<slug>/restore`.
+
+## Schema (`doc_revisions`)
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | int PK | Internal ordering. Never exposed in API. |
+| `external_id` | text, unique | Slug-style, e.g. `rv_aB12...`. What the API and UI use. |
+| `doc_id` | FK → `docs.id` | Cascade on delete. |
+| `content` | text | Full snapshot. No deltas. |
+| `summary` | text, nullable | Headline for UI rows. Agent batch-edits self-summarize ("Replaced 23 em-dashes; rewrote intro"). Manual edits default to "Manual edit." Restores get "Restored from `<external_id>`." |
+| `source` | enum | `'manual' \| 'cli' \| 'agent' \| 'restore'`. See "Source enum" below. |
+| `created_by` | text (owner_id) | Same shape as `docs.owner_id`. |
+| `created_at` | timestamptz | Ordering + display. |
+| `bytes_added` | int | Computed at write time via `DiffStats`. |
+| `bytes_removed` | int | Computed at write time via `DiffStats`. |
+
+**Retention:** keep last 50 per doc; prune on insert. User-configurable later if it ever matters.
+
+**Snapshots, not deltas.** O(1) restore. At a 1MB cap × 50 revisions × small doc count, storage is fine on Neon. Don't trade simplicity for storage we don't need to save.
+
+## Source enum
+
+`'manual' | 'cli' | 'agent' | 'restore'`. Values reflect *endpoint context*, not auth method. Auth method couldn't distinguish what the UI needs to show — a curl from a human and an agent-driven call both present as bearer.
+
+| Value | Meaning | Set by |
+|---|---|---|
+| `'manual'` | Dashboard UI write (session-authed) | PATCH handler |
+| `'cli'` | `/api/*` write with bearer auth | PATCH handler |
+| `'agent'` | `/api/agent/*` write (#46) | Agent edit handler — **reserved in #45**, used in #46 |
+| `'restore'` | Any restore action, regardless of who triggered it | `/restore` handler |
+
+The `'agent'` value is added to the enum in #45 even though no caller uses it yet, so #46 doesn't require an enum extension migration.
+
+## API verbs (live on `/api/*`, not AI-specific)
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| `GET` | `/api/docs/<slug>/revisions` | bearer or session | Paginated, metadata only (no content). `?limit=`, `?cursor=`. |
+| `GET` | `/api/docs/<slug>/revisions/<id>` | bearer or session | Single revision content. |
+| `POST` | `/api/docs/<slug>/restore` | bearer or session | Body: `{revisionId}`. Reads via `RevisionLog.get`, writes via `DocMutationPath` with `source: 'restore'`. The restore is itself recorded as a new revision. |
+
+Existing `PATCH /api/docs/<slug>` is refactored to call `DocMutationPath.writeDocContent` instead of mutating content inline.
+
+## Restore is itself a revision
+
+`POST /api/docs/<slug>/restore` does three things:
+1. `RevisionLog.get(docId, revisionId)` — fetch old content.
+2. `DocMutationPath.writeDocContent({newContent: oldContent, summary: "Restored from rv_xY8z", source: 'restore', ownerId})`.
+3. Return the new version.
+
+Step 2 records a *new* revision automatically — the linear audit trail has no special-case "this got restored" annotation. The history UI shows the restore as a row with `source: 'restore'`.
+
+## Out of scope for #45
+
+| Item | Why deferred |
+|---|---|
+| Title/kind changes don't snapshot content | "History" intuitively means content history. Title-only edits shouldn't pollute revision rows. If renames become a recovery need, add a separate entry type later. |
+| DELETE is not undoable | Soft-delete is its own feature. Deleting a doc cascades its revisions and stays gone. |
+| Optimistic concurrency (`If-Match`) | Defers to #46 phase 2. |
+| Diff endpoint (`/diff?from=...&to=...`) | UI can compute diffs client-side from `bytes_added/removed` + content. Server-side diff is a phase-2 win once real usage points at the need. |
+
+## What this gets us
+
+- **One mutation chokepoint.** Every content write — past, present, future — flows through `DocMutationPath`. There is no second code path.
+- **History as a structural property, not a feature.** Recording is automatic; no caller can forget.
+- **Clean handoff to #46.** The agent edit handler is one extra line: `await DocMutationPath.writeDocContent({..., source: 'agent'})`. No duplicated wiring.
+- **UI privacy.** History never leaks to public reader. Authed-route shape matches the rest of the dashboard.
+- **Linear audit trail.** Restores show up as their own row, no special-case annotation.
+
+## Build order inside the ticket
+
+1. Schema migration: `doc_revisions` table + `source` enum (with all four values).
+2. `DiffStats` (pure utility, fully unit-testable).
+3. `RevisionLog` (record / list / get / internal prune).
+4. `DocMutationPath` (calls `RevisionLog.record`).
+5. Refactor `PATCH /api/docs/<slug>` to use `DocMutationPath`.
+6. New API verbs: `/revisions`, `/revisions/<id>`, `/restore`.
+7. History UI: list route, view route, restore confirm flow.
+8. Mobile parity pass.
+
+Steps 1–4 are pure backend, fully unit-testable, no UI consumer. Step 5 is the smallest possible refactor (existing tests should stay green). Step 6 is thin glue. Steps 7–8 are the bulk of the visible work.

--- a/migrations/007_create_doc_revisions_table.sql
+++ b/migrations/007_create_doc_revisions_table.sql
@@ -1,0 +1,28 @@
+-- 007_create_doc_revisions_table.sql
+-- Document revision history (issue #45).
+-- Captures pre-write content snapshots so any successful mutation through
+-- DocMutationPath is recoverable. Feeds the dashboard history UI and
+-- (later, via #46) the agent edit/restore endpoints.
+--
+-- The 'agent' source value is reserved here for #46 so that ticket needs no
+-- enum extension migration. Until #46 ships nothing inserts with source='agent'.
+
+CREATE TYPE doc_revision_source AS ENUM ('manual', 'cli', 'agent', 'restore');
+
+CREATE TABLE doc_revisions (
+  id bigserial PRIMARY KEY,
+  external_id text UNIQUE NOT NULL,
+  doc_id uuid NOT NULL REFERENCES docs(id) ON DELETE CASCADE,
+  content text NOT NULL,
+  summary text,
+  source doc_revision_source NOT NULL,
+  created_by text NOT NULL,
+  bytes_added integer NOT NULL DEFAULT 0,
+  bytes_removed integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- List newest-first per doc, with (created_at, id) cursor support that mirrors
+-- the docs listing pagination shape.
+CREATE INDEX idx_doc_revisions_doc_created
+  ON doc_revisions (doc_id, created_at DESC, id DESC);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@shikijs/rehype": "^4.0.2",
     "@vercel/postgres": "^0.10.0",
     "@workos-inc/authkit-nextjs": "^4.0.1",
+    "diff": "^9.0.0",
     "hast-util-to-string": "^3.0.1",
     "mermaid": "^11.14.0",
     "nanoid": "^5.1.9",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/typography": "^0.5.19",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/hast": "^3.0.4",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -40,6 +43,7 @@
     "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "happy-dom": "^20.9.0",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@workos-inc/authkit-nextjs':
         specifier: ^4.0.1
         version: 4.0.1(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       hast-util-to-string:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1698,6 +1701,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -4924,6 +4931,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@9.0.0: {}
 
   doctrine@2.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,15 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.4)
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -87,6 +96,9 @@ importers:
       eslint-config-next:
         specifier: 16.2.4
         version: 16.2.4(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0(bufferutil@4.1.0)
       tailwindcss:
         specifier: ^4
         version: 4.2.4
@@ -98,9 +110,12 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@20.19.39)(@vitest/ui@4.1.5)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.5(@types/node@20.19.39)(@vitest/ui@4.1.5)(happy-dom@20.9.0(bufferutil@4.1.0))(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -163,6 +178,10 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -900,8 +919,34 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1054,6 +1099,12 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.59.0':
     resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
@@ -1279,12 +1330,23 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1474,6 +1536,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1710,6 +1775,12 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dompurify@3.4.1:
     resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
@@ -1730,6 +1801,10 @@ packages:
   enhanced-resolve@5.21.0:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -2038,6 +2113,10 @@ packages:
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2108,6 +2187,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -2420,6 +2503,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2574,6 +2661,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2809,6 +2900,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2830,6 +2925,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
@@ -2839,6 +2937,10 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3032,6 +3134,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -3324,6 +3430,10 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3386,6 +3496,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -3470,6 +3582,8 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -4045,10 +4159,42 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.4
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4226,6 +4372,12 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.39
 
   '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4436,7 +4588,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@20.19.39)(@vitest/ui@4.1.5)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      vitest: 4.1.5(@types/node@20.19.39)(@vitest/ui@4.1.5)(happy-dom@20.9.0(bufferutil@4.1.0))(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -4475,11 +4627,19 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -4683,6 +4843,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
 
@@ -4938,6 +5100,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dompurify@3.4.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -4958,6 +5124,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@7.0.1: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -5433,6 +5601,18 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
+  happy-dom@20.9.0(bufferutil@4.1.0):
+    dependencies:
+      '@types/node': 20.19.39
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0(bufferutil@4.1.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -5521,6 +5701,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -5811,6 +5993,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -6197,6 +6381,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -6434,6 +6620,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -6452,6 +6644,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -6472,6 +6666,11 @@ snapshots:
       - supports-color
 
   react@19.2.4: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6796,6 +6995,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   style-to-js@1.1.21:
@@ -7030,7 +7233,7 @@ snapshots:
       jiti: 2.6.1
       tsx: 4.21.0
 
-  vitest@4.1.5(@types/node@20.19.39)(@vitest/ui@4.1.5)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
+  vitest@4.1.5(@types/node@20.19.39)(@vitest/ui@4.1.5)(happy-dom@20.9.0(bufferutil@4.1.0))(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
@@ -7055,6 +7258,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
       '@vitest/ui': 4.1.5(vitest@4.1.5)
+      happy-dom: 20.9.0(bufferutil@4.1.0)
     transitivePeerDependencies:
       - msw
 
@@ -7074,6 +7278,8 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/api/docs/[slug]/restore/route.test.ts
+++ b/src/app/api/docs/[slug]/restore/route.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "@/lib/api-tokens";
+import { getDocBySlug, insertDoc, type Doc } from "@/lib/db";
+import { generateSlug } from "@/lib/slug";
+import { stripMarkdown } from "@/lib/strip-md";
+import * as RevisionLog from "@/lib/revision-log";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { POST } from "./route";
+
+const TEST_OWNER = "__test_restore_route__";
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set — route tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER + "_other"}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER + "_other"}`;
+});
+
+async function setup(content: string, ownerId = TEST_OWNER) {
+  const token = await createApiToken(ownerId, "test");
+  const doc: Doc = await insertDoc({
+    slug: generateSlug(),
+    ownerId,
+    title: "T",
+    content,
+    kind: null,
+    searchText: stripMarkdown(content),
+  });
+  return { token, doc };
+}
+
+function postReq(slug: string, body: object, token: string) {
+  const url = `http://localhost/api/docs/${slug}/restore`;
+  const req = new NextRequest(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  return POST(req, { params: Promise.resolve({ slug }) });
+}
+
+describe("POST /api/docs/[slug]/restore", () => {
+  it("restores prior content and records the restore as a new revision", async () => {
+    const { token, doc } = await setup("v0");
+    // Snapshot v0 by editing through the chokepoint.
+    const recorded = await RevisionLog.record({
+      docId: doc.id,
+      prevContent: "v0",
+      nextContent: "v1",
+      summary: "first edit",
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    // Pretend the doc has been advanced past v1.
+    await sql`UPDATE docs SET content = 'v1' WHERE id = ${doc.id}`;
+
+    const res = await postReq(
+      doc.slug,
+      { revisionId: recorded.externalId },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+
+    const persisted = await getDocBySlug(doc.slug);
+    expect(persisted?.content).toBe("v0");
+
+    const listed = await RevisionLog.list(doc.id);
+    // Expect the original revision plus a new 'restore' revision capturing v1.
+    expect(listed.revisions).toHaveLength(2);
+    const newest = listed.revisions[0]!;
+    expect(newest.source).toBe("restore");
+    const restoreRev = await RevisionLog.get(doc.id, newest.externalId);
+    expect(restoreRev?.content).toBe("v1");
+  });
+
+  it("returns 400 for missing revisionId", async () => {
+    const { token, doc } = await setup("body");
+    const res = await postReq(doc.slug, {}, token.plaintext);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown revisionId", async () => {
+    const { token, doc } = await setup("body");
+    const res = await postReq(
+      doc.slug,
+      { revisionId: "rv_nope" },
+      token.plaintext,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the bearer's owner doesn't match the doc owner", async () => {
+    const { doc } = await setup("body", TEST_OWNER);
+    const recorded = await RevisionLog.record({
+      docId: doc.id,
+      prevContent: "body",
+      nextContent: "next",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    const otherToken = await createApiToken(TEST_OWNER + "_other", "tok");
+    const res = await postReq(
+      doc.slug,
+      { revisionId: recorded.externalId },
+      otherToken.plaintext,
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/docs/[slug]/restore/route.ts
+++ b/src/app/api/docs/[slug]/restore/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/lib/auth";
+import { getDocBySlug } from "@/lib/db";
+import { writeDocContent } from "@/lib/doc-mutation-path";
+import { resolveTitle } from "@/lib/title";
+import { stripMarkdown } from "@/lib/strip-md";
+import * as RevisionLog from "@/lib/revision-log";
+
+function jsonError(status: number, message: string) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+type Body = { revisionId?: unknown };
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ slug: string }> },
+) {
+  const auth = await requireAuth(req);
+  if (!auth.authenticated) {
+    return jsonError(auth.status, auth.reason);
+  }
+
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return jsonError(400, "Invalid JSON body");
+  }
+  if (
+    !body ||
+    typeof body !== "object" ||
+    typeof body.revisionId !== "string" ||
+    !body.revisionId
+  ) {
+    return jsonError(400, "revisionId is required");
+  }
+
+  const { slug } = await context.params;
+  const doc = await getDocBySlug(slug);
+  if (!doc || doc.ownerId !== auth.ownerId) {
+    return jsonError(404, "Document not found");
+  }
+
+  const revision = await RevisionLog.get(doc.id, body.revisionId);
+  if (!revision) {
+    return jsonError(404, "Revision not found");
+  }
+
+  const result = await writeDocContent({
+    docId: doc.id,
+    newContent: revision.content,
+    newTitle: resolveTitle(revision.content, null),
+    newSearchText: stripMarkdown(revision.content),
+    summary: `Restored from ${revision.externalId}`,
+    source: "restore",
+    ownerId: auth.ownerId,
+  });
+
+  revalidatePath("/");
+  revalidatePath(`/v/${slug}`);
+
+  return new Response(
+    JSON.stringify({
+      doc: {
+        id: result.doc.id,
+        slug: result.doc.slug,
+        title: result.doc.title,
+        kind: result.doc.kind,
+        content: result.doc.content,
+        createdAt: result.doc.createdAt,
+        updatedAt: result.doc.updatedAt,
+      },
+      revisionId: result.revisionId,
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}

--- a/src/app/api/docs/[slug]/restore/route.ts
+++ b/src/app/api/docs/[slug]/restore/route.ts
@@ -1,18 +1,10 @@
 import { NextRequest } from "next/server";
 import { revalidatePath } from "next/cache";
-import { requireAuth } from "@/lib/auth";
-import { getDocBySlug } from "@/lib/db";
 import { writeDocContent } from "@/lib/doc-mutation-path";
 import { resolveTitle } from "@/lib/title";
 import { stripMarkdown } from "@/lib/strip-md";
 import * as RevisionLog from "@/lib/revision-log";
-
-function jsonError(status: number, message: string) {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
+import { jsonError, requireOwnedDoc } from "@/lib/route-helpers";
 
 type Body = { revisionId?: unknown };
 
@@ -20,11 +12,6 @@ export async function POST(
   req: NextRequest,
   context: { params: Promise<{ slug: string }> },
 ) {
-  const auth = await requireAuth(req);
-  if (!auth.authenticated) {
-    return jsonError(auth.status, auth.reason);
-  }
-
   let body: Body;
   try {
     body = (await req.json()) as Body;
@@ -41,10 +28,9 @@ export async function POST(
   }
 
   const { slug } = await context.params;
-  const doc = await getDocBySlug(slug);
-  if (!doc || doc.ownerId !== auth.ownerId) {
-    return jsonError(404, "Document not found");
-  }
+  const owned = await requireOwnedDoc(req, slug);
+  if (!owned.ok) return owned.response;
+  const { auth, doc } = owned;
 
   const revision = await RevisionLog.get(doc.id, body.revisionId);
   if (!revision) {

--- a/src/app/api/docs/[slug]/revisions/[id]/route.test.ts
+++ b/src/app/api/docs/[slug]/revisions/[id]/route.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "@/lib/api-tokens";
+import { insertDoc, type Doc } from "@/lib/db";
+import { generateSlug } from "@/lib/slug";
+import { stripMarkdown } from "@/lib/strip-md";
+import * as RevisionLog from "@/lib/revision-log";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { GET } from "./route";
+
+const TEST_OWNER = "__test_revision_id_route__";
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set — route tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER + "_other"}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER + "_other"}`;
+});
+
+async function setup(content: string, ownerId = TEST_OWNER) {
+  const token = await createApiToken(ownerId, "test");
+  const doc: Doc = await insertDoc({
+    slug: generateSlug(),
+    ownerId,
+    title: "T",
+    content,
+    kind: null,
+    searchText: stripMarkdown(content),
+  });
+  return { token, doc };
+}
+
+function getReq(slug: string, id: string, token: string) {
+  const url = `http://localhost/api/docs/${slug}/revisions/${id}`;
+  const req = new NextRequest(url, {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  return GET(req, { params: Promise.resolve({ slug, id }) });
+}
+
+describe("GET /api/docs/[slug]/revisions/[id]", () => {
+  it("returns full revision content for the owner", async () => {
+    const { token, doc } = await setup("Before");
+    const recorded = await RevisionLog.record({
+      docId: doc.id,
+      prevContent: "Before",
+      nextContent: "After",
+      summary: "edit",
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+
+    const res = await getReq(doc.slug, recorded.externalId, token.plaintext);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { content: string; summary: string };
+    expect(body.content).toBe("Before");
+    expect(body.summary).toBe("edit");
+  });
+
+  it("returns 404 for unknown revisionId", async () => {
+    const { token, doc } = await setup("body");
+    const res = await getReq(doc.slug, "rv_nope", token.plaintext);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the bearer's owner doesn't match the doc owner", async () => {
+    const { doc } = await setup("body", TEST_OWNER);
+    const recorded = await RevisionLog.record({
+      docId: doc.id,
+      prevContent: "body",
+      nextContent: "body2",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    const otherToken = await createApiToken(TEST_OWNER + "_other", "tok");
+    const res = await getReq(
+      doc.slug,
+      recorded.externalId,
+      otherToken.plaintext,
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/docs/[slug]/revisions/[id]/route.ts
+++ b/src/app/api/docs/[slug]/revisions/[id]/route.ts
@@ -1,29 +1,15 @@
 import { NextRequest } from "next/server";
-import { requireAuth } from "@/lib/auth";
-import { getDocBySlug } from "@/lib/db";
 import * as RevisionLog from "@/lib/revision-log";
-
-function jsonError(status: number, message: string) {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
+import { jsonError, requireOwnedDoc } from "@/lib/route-helpers";
 
 export async function GET(
   req: NextRequest,
   context: { params: Promise<{ slug: string; id: string }> },
 ) {
-  const auth = await requireAuth(req);
-  if (!auth.authenticated) {
-    return jsonError(auth.status, auth.reason);
-  }
-
   const { slug, id } = await context.params;
-  const doc = await getDocBySlug(slug);
-  if (!doc || doc.ownerId !== auth.ownerId) {
-    return jsonError(404, "Document not found");
-  }
+  const owned = await requireOwnedDoc(req, slug);
+  if (!owned.ok) return owned.response;
+  const { doc } = owned;
 
   const revision = await RevisionLog.get(doc.id, id);
   if (!revision) {

--- a/src/app/api/docs/[slug]/revisions/[id]/route.ts
+++ b/src/app/api/docs/[slug]/revisions/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getDocBySlug } from "@/lib/db";
+import * as RevisionLog from "@/lib/revision-log";
+
+function jsonError(status: number, message: string) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ slug: string; id: string }> },
+) {
+  const auth = await requireAuth(req);
+  if (!auth.authenticated) {
+    return jsonError(auth.status, auth.reason);
+  }
+
+  const { slug, id } = await context.params;
+  const doc = await getDocBySlug(slug);
+  if (!doc || doc.ownerId !== auth.ownerId) {
+    return jsonError(404, "Document not found");
+  }
+
+  const revision = await RevisionLog.get(doc.id, id);
+  if (!revision) {
+    return jsonError(404, "Revision not found");
+  }
+
+  return new Response(
+    JSON.stringify({
+      externalId: revision.externalId,
+      content: revision.content,
+      summary: revision.summary,
+      source: revision.source,
+      createdBy: revision.createdBy,
+      bytesAdded: revision.bytesAdded,
+      bytesRemoved: revision.bytesRemoved,
+      createdAt: revision.createdAt,
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}

--- a/src/app/api/docs/[slug]/revisions/route.test.ts
+++ b/src/app/api/docs/[slug]/revisions/route.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "@/lib/api-tokens";
+import { insertDoc, type Doc } from "@/lib/db";
+import { generateSlug } from "@/lib/slug";
+import { stripMarkdown } from "@/lib/strip-md";
+import * as RevisionLog from "@/lib/revision-log";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { GET } from "./route";
+
+const TEST_OWNER = "__test_revisions_route__";
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set — route tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER + "_other"}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER + "_other"}`;
+});
+
+async function setup(content: string, ownerId = TEST_OWNER) {
+  const token = await createApiToken(ownerId, "test");
+  const doc: Doc = await insertDoc({
+    slug: generateSlug(),
+    ownerId,
+    title: "T",
+    content,
+    kind: null,
+    searchText: stripMarkdown(content),
+  });
+  return { token, doc };
+}
+
+function getReq(slug: string, token: string, search = "") {
+  const url = `http://localhost/api/docs/${slug}/revisions${search}`;
+  const req = new NextRequest(url, {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  return GET(req, { params: Promise.resolve({ slug }) });
+}
+
+describe("GET /api/docs/[slug]/revisions security", () => {
+  it("returns 404 when the bearer token's owner doesn't match the doc owner", async () => {
+    const { doc } = await setup("v0", TEST_OWNER); // owned by TEST_OWNER
+    const otherToken = await createApiToken(TEST_OWNER + "_other", "tok");
+    const res = await getReq(doc.slug, otherToken.plaintext);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/docs/[slug]/revisions", () => {
+  it("returns the revisions list for the doc owner, newest-first", async () => {
+    const { token, doc } = await setup("v0");
+    await RevisionLog.record({
+      docId: doc.id,
+      prevContent: "v0",
+      nextContent: "v1",
+      summary: "first",
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    await RevisionLog.record({
+      docId: doc.id,
+      prevContent: "v1",
+      nextContent: "v2",
+      summary: "second",
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+
+    const res = await getReq(doc.slug, token.plaintext);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      revisions: Array<{ summary: string }>;
+      nextCursor: string | null;
+    };
+    expect(body.revisions.map((r) => r.summary)).toEqual(["second", "first"]);
+    expect(body.nextCursor).toBeNull();
+  });
+});

--- a/src/app/api/docs/[slug]/revisions/route.ts
+++ b/src/app/api/docs/[slug]/revisions/route.ts
@@ -14,7 +14,9 @@ export async function GET(
   const url = new URL(req.url);
   const limitParam = url.searchParams.get("limit");
   const cursorParam = url.searchParams.get("cursor") ?? undefined;
-  const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+  const limitParsed = limitParam ? parseInt(limitParam, 10) : NaN;
+  const limit =
+    Number.isFinite(limitParsed) && limitParsed > 0 ? limitParsed : undefined;
 
   const result = await RevisionLog.list(doc.id, { limit, cursor: cursorParam });
   return new Response(

--- a/src/app/api/docs/[slug]/revisions/route.ts
+++ b/src/app/api/docs/[slug]/revisions/route.ts
@@ -1,29 +1,15 @@
 import { NextRequest } from "next/server";
-import { requireAuth } from "@/lib/auth";
-import { getDocBySlug } from "@/lib/db";
 import * as RevisionLog from "@/lib/revision-log";
-
-function jsonError(status: number, message: string) {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
+import { requireOwnedDoc } from "@/lib/route-helpers";
 
 export async function GET(
   req: NextRequest,
   context: { params: Promise<{ slug: string }> },
 ) {
-  const auth = await requireAuth(req);
-  if (!auth.authenticated) {
-    return jsonError(auth.status, auth.reason);
-  }
-
   const { slug } = await context.params;
-  const doc = await getDocBySlug(slug);
-  if (!doc || doc.ownerId !== auth.ownerId) {
-    return jsonError(404, "Document not found");
-  }
+  const owned = await requireOwnedDoc(req, slug);
+  if (!owned.ok) return owned.response;
+  const { doc } = owned;
 
   const url = new URL(req.url);
   const limitParam = url.searchParams.get("limit");

--- a/src/app/api/docs/[slug]/revisions/route.ts
+++ b/src/app/api/docs/[slug]/revisions/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getDocBySlug } from "@/lib/db";
+import * as RevisionLog from "@/lib/revision-log";
+
+function jsonError(status: number, message: string) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ slug: string }> },
+) {
+  const auth = await requireAuth(req);
+  if (!auth.authenticated) {
+    return jsonError(auth.status, auth.reason);
+  }
+
+  const { slug } = await context.params;
+  const doc = await getDocBySlug(slug);
+  if (!doc || doc.ownerId !== auth.ownerId) {
+    return jsonError(404, "Document not found");
+  }
+
+  const url = new URL(req.url);
+  const limitParam = url.searchParams.get("limit");
+  const cursorParam = url.searchParams.get("cursor") ?? undefined;
+  const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+
+  const result = await RevisionLog.list(doc.id, { limit, cursor: cursorParam });
+  return new Response(
+    JSON.stringify({
+      revisions: result.revisions.map((r) => ({
+        externalId: r.externalId,
+        summary: r.summary,
+        source: r.source,
+        createdBy: r.createdBy,
+        bytesAdded: r.bytesAdded,
+        bytesRemoved: r.bytesRemoved,
+        createdAt: r.createdAt,
+      })),
+      nextCursor: result.nextCursor,
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}

--- a/src/app/api/docs/[slug]/route.test.ts
+++ b/src/app/api/docs/[slug]/route.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "@/lib/api-tokens";
+import { insertDoc } from "@/lib/db";
+import { generateSlug } from "@/lib/slug";
+import { stripMarkdown } from "@/lib/strip-md";
+import * as RevisionLog from "@/lib/revision-log";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// Stub the WorkOS authkit module so importing @/lib/auth doesn't pull in
+// next/cache transitively from a path Vitest can't resolve.
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { PATCH } from "./route";
+
+const TEST_OWNER = "__test_patch_route__";
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set — route tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+});
+
+async function setupAuthorizedDoc(content: string) {
+  const token = await createApiToken(TEST_OWNER, "test");
+  const doc = await insertDoc({
+    slug: generateSlug(),
+    ownerId: TEST_OWNER,
+    title: "Test",
+    content,
+    kind: null,
+    searchText: stripMarkdown(content),
+  });
+  return { token, doc };
+}
+
+function patchReq(slug: string, body: object, token: string) {
+  const req = new NextRequest(`http://localhost/api/docs/${slug}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  return PATCH(req, { params: Promise.resolve({ slug }) });
+}
+
+describe("PATCH /api/docs/[slug] revision creation", () => {
+  it("creates a revision capturing prior content when content changes (bearer → source: cli)", async () => {
+    const { token, doc } = await setupAuthorizedDoc("# Before\n\nbody");
+    const res = await patchReq(
+      doc.slug,
+      { content: "# After\n\nbody" },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(1);
+    expect(listed.revisions[0]?.source).toBe("cli");
+
+    const revision = await RevisionLog.get(
+      doc.id,
+      listed.revisions[0]!.externalId,
+    );
+    expect(revision?.content).toBe("# Before\n\nbody");
+  });
+
+  it("does NOT create a revision when only title changes (no content write)", async () => {
+    const { token, doc } = await setupAuthorizedDoc("v0");
+    const res = await patchReq(doc.slug, { title: "Renamed" }, token.plaintext);
+    expect(res.status).toBe(200);
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(0);
+  });
+});

--- a/src/app/api/docs/[slug]/route.test.ts
+++ b/src/app/api/docs/[slug]/route.test.ts
@@ -86,4 +86,18 @@ describe("PATCH /api/docs/[slug] revision creation", () => {
     const listed = await RevisionLog.list(doc.id);
     expect(listed.revisions).toHaveLength(0);
   });
+
+  it("does NOT create a revision when content is submitted but unchanged from the existing value", async () => {
+    const { token, doc } = await setupAuthorizedDoc("identical body");
+    // Round-tripping the same content through PATCH should not burn a slot.
+    const res = await patchReq(
+      doc.slug,
+      { content: "identical body", title: "Renamed" },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(0);
+  });
 });

--- a/src/app/api/docs/[slug]/route.ts
+++ b/src/app/api/docs/[slug]/route.ts
@@ -113,8 +113,14 @@ export async function PATCH(
     nextTitle = resolveTitle(sourceContent, explicit);
   }
 
+  // A no-op content PATCH (same string as existing.content) shouldn't burn a
+  // retention slot. Compare exactly; the content column is opaque text.
   let updated;
-  if (hasContent && nextContent !== undefined) {
+  if (
+    hasContent &&
+    nextContent !== undefined &&
+    nextContent !== existing.content
+  ) {
     // Route through DocMutationPath so the prior content is snapshotted as a
     // revision in the same transaction as the docs UPDATE.
     const source: RevisionSource = auth.via === "session" ? "manual" : "cli";

--- a/src/app/api/docs/[slug]/route.ts
+++ b/src/app/api/docs/[slug]/route.ts
@@ -1,31 +1,22 @@
 import { NextRequest } from "next/server";
 import { revalidatePath } from "next/cache";
 import { requireAuth } from "@/lib/auth";
-import {
-  deleteDocBySlug,
-  getDocBySlug,
-  updateDocBySlug,
-  type UpdateDocFields,
-} from "@/lib/db";
+import { deleteDocBySlug, updateDocBySlug, type UpdateDocFields } from "@/lib/db";
 import { writeDocContent } from "@/lib/doc-mutation-path";
 import type { RevisionSource } from "@/lib/revision-log";
 import { resolveTitle } from "@/lib/title";
 import { stripMarkdown } from "@/lib/strip-md";
 import { parseKind } from "@/lib/kind";
+import { jsonError, requireOwnedDoc } from "@/lib/route-helpers";
 
 const MAX_BYTES = 1024 * 1024;
-
-function jsonError(status: number, message: string) {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
 
 export async function DELETE(
   req: NextRequest,
   context: { params: Promise<{ slug: string }> },
 ) {
+  // DELETE does ownership-checking inside deleteDocBySlug's WHERE clause, so
+  // skip the requireOwnedDoc SELECT round-trip here.
   const auth = await requireAuth(req);
   if (!auth.authenticated) {
     return jsonError(auth.status, auth.reason);
@@ -53,11 +44,6 @@ export async function PATCH(
   req: NextRequest,
   context: { params: Promise<{ slug: string }> },
 ) {
-  const auth = await requireAuth(req);
-  if (!auth.authenticated) {
-    return jsonError(auth.status, auth.reason);
-  }
-
   const { slug } = await context.params;
 
   const contentLength = req.headers.get("content-length");
@@ -113,11 +99,9 @@ export async function PATCH(
     nextKind = parsed.value;
   }
 
-  const existing = await getDocBySlug(slug);
-  if (!existing || existing.ownerId !== auth.ownerId) {
-    // 404 (not 403) on owner mismatch — don't leak existence to non-owners.
-    return jsonError(404, "Document not found");
-  }
+  const owned = await requireOwnedDoc(req, slug);
+  if (!owned.ok) return owned.response;
+  const { auth, doc: existing } = owned;
 
   // Title resolution mirrors upload semantics: explicit override → first H1 → "Untitled".
   // Recompute when content changes (so the H1 stays in sync) or when the caller

--- a/src/app/api/docs/[slug]/route.ts
+++ b/src/app/api/docs/[slug]/route.ts
@@ -7,6 +7,8 @@ import {
   updateDocBySlug,
   type UpdateDocFields,
 } from "@/lib/db";
+import { writeDocContent } from "@/lib/doc-mutation-path";
+import type { RevisionSource } from "@/lib/revision-log";
 import { resolveTitle } from "@/lib/title";
 import { stripMarkdown } from "@/lib/strip-md";
 import { parseKind } from "@/lib/kind";
@@ -117,29 +119,43 @@ export async function PATCH(
     return jsonError(404, "Document not found");
   }
 
-  const fields: UpdateDocFields = {};
-
   // Title resolution mirrors upload semantics: explicit override → first H1 → "Untitled".
   // Recompute when content changes (so the H1 stays in sync) or when the caller
   // sends a title (including null/empty to re-derive from H1).
+  let nextTitle: string | undefined;
   if (hasContent || hasTitle) {
     const sourceContent = nextContent ?? existing.content;
     const explicit = hasTitle ? titleOverride : existing.title;
-    fields.title = resolveTitle(sourceContent, explicit);
+    nextTitle = resolveTitle(sourceContent, explicit);
   }
 
+  let updated;
   if (hasContent && nextContent !== undefined) {
-    fields.content = nextContent;
-    fields.searchText = stripMarkdown(nextContent);
-  }
-
-  if (hasKind) {
-    fields.kind = nextKind ?? null;
-  }
-
-  const updated = await updateDocBySlug(slug, fields);
-  if (!updated) {
-    return jsonError(404, "Document not found");
+    // Route through DocMutationPath so the prior content is snapshotted as a
+    // revision in the same transaction as the docs UPDATE.
+    const source: RevisionSource = auth.via === "session" ? "manual" : "cli";
+    const summary = auth.via === "session" ? "Manual edit" : null;
+    const result = await writeDocContent({
+      docId: existing.id,
+      newContent: nextContent,
+      newTitle: nextTitle,
+      newSearchText: stripMarkdown(nextContent),
+      newKind: hasKind ? (nextKind ?? null) : undefined,
+      summary,
+      source,
+      ownerId: auth.ownerId,
+    });
+    updated = result.doc;
+  } else {
+    // Title-only and/or kind-only edits don't snapshot content; keep them on
+    // the existing path that doesn't touch doc_revisions.
+    const fields: UpdateDocFields = {};
+    if (nextTitle !== undefined) fields.title = nextTitle;
+    if (hasKind) fields.kind = nextKind ?? null;
+    updated = await updateDocBySlug(slug, fields);
+    if (!updated) {
+      return jsonError(404, "Document not found");
+    }
   }
 
   revalidatePath("/");

--- a/src/app/edit/[slug]/revisions/[id]/page.tsx
+++ b/src/app/edit/[slug]/revisions/[id]/page.tsx
@@ -7,6 +7,7 @@ import * as RevisionLog from "@/lib/revision-log";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { FrontmatterDisclosure } from "@/components/frontmatter-disclosure";
 import { parseFrontmatter } from "@/lib/frontmatter";
+import { formatSource, shouldShowSourceLabel } from "@/lib/revision-display";
 import { RestoreAction } from "@/components/restore-action";
 
 type PageProps = {
@@ -80,21 +81,24 @@ export default async function RevisionDetailPage({ params }: PageProps) {
           &larr; All revisions
         </Link>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
-          <div className="flex flex-col gap-1">
-            <p
-              className="font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted [font-variant-numeric:tabular-nums]"
-              title={revision.createdAt.toISOString()}
-            >
+          <div className="flex min-w-0 flex-col gap-1.5">
+            <p className="flex items-baseline gap-x-2 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
               <span>Revision</span>
-              <span className="mx-2 normal-case tracking-[0.04em] text-ink">
+              <span className="normal-case tracking-[0.04em] text-ink">
                 {revision.externalId}
               </span>
-              <span aria-hidden="true">·</span>
-              <span className="ml-2">{formatDate(revision.createdAt)}</span>
-              <span aria-hidden="true" className="mx-2">
-                ·
-              </span>
-              <span>{revision.source}</span>
+            </p>
+            <p
+              className="flex flex-wrap items-baseline gap-x-3 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted [font-variant-numeric:tabular-nums]"
+              title={revision.createdAt.toISOString()}
+            >
+              <span>{formatDate(revision.createdAt)}</span>
+              {shouldShowSourceLabel(revision.source) ? (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span>{formatSource(revision.source)}</span>
+                </>
+              ) : null}
             </p>
             {revision.summary ? (
               <p className="text-[0.9375rem] text-ink">{revision.summary}</p>

--- a/src/app/edit/[slug]/revisions/[id]/page.tsx
+++ b/src/app/edit/[slug]/revisions/[id]/page.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link";
+import { redirect, notFound } from "next/navigation";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { isEmailAllowed } from "@/lib/access";
+import { getDocBySlug } from "@/lib/db";
+import * as RevisionLog from "@/lib/revision-log";
+import { MarkdownRenderer } from "@/components/markdown-renderer";
+import { RestoreAction } from "@/components/restore-action";
+
+type PageProps = {
+  params: Promise<{ slug: string; id: string }>;
+};
+
+export const metadata = {
+  title: "Revision",
+  robots: { index: false, follow: false },
+};
+
+const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+const DATE_FORMAT_PRIOR_YEAR = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+function formatDate(d: Date): string {
+  const now = new Date();
+  const fmt =
+    d.getFullYear() !== now.getFullYear() ? DATE_FORMAT_PRIOR_YEAR : DATE_FORMAT;
+  return fmt.format(d).toUpperCase().replace(",", "");
+}
+
+export default async function RevisionDetailPage({ params }: PageProps) {
+  const { user } = await withAuth();
+  if (!user) redirect("/auth");
+  if (!isEmailAllowed(user.email)) redirect("/");
+
+  const { slug, id } = await params;
+  const doc = await getDocBySlug(slug);
+  if (!doc || doc.ownerId !== user.id) notFound();
+
+  const revision = await RevisionLog.get(doc.id, id);
+  if (!revision) {
+    return (
+      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
+        <p className="text-sm text-muted">Revision not found.</p>
+        <Link
+          href={`/edit/${slug}/revisions`}
+          prefetch={false}
+          className="mt-4 inline-block font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted transition-colors hover:text-ochre"
+        >
+          &larr; All revisions
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
+      {/* Header strip — non-sticky context that says "this is historical". */}
+      <header className="mb-8 border-b border-border pb-4">
+        <Link
+          href={`/edit/${slug}/revisions`}
+          prefetch={false}
+          className="mb-2 inline-block font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted transition-colors hover:text-ochre"
+        >
+          &larr; All revisions
+        </Link>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+          <div className="flex flex-col gap-1">
+            <p
+              className="font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted [font-variant-numeric:tabular-nums]"
+              title={revision.createdAt.toISOString()}
+            >
+              <span>Revision</span>
+              <span className="mx-2 normal-case tracking-[0.04em] text-ink">
+                {revision.externalId}
+              </span>
+              <span aria-hidden="true">·</span>
+              <span className="ml-2">{formatDate(revision.createdAt)}</span>
+              <span aria-hidden="true" className="mx-2">
+                ·
+              </span>
+              <span>{revision.source}</span>
+            </p>
+            {revision.summary ? (
+              <p className="text-[0.9375rem] text-ink">{revision.summary}</p>
+            ) : null}
+          </div>
+          <RestoreAction slug={slug} revisionId={revision.externalId} />
+        </div>
+      </header>
+
+      <article className="prose prose-neutral max-w-none">
+        <MarkdownRenderer content={revision.content} />
+      </article>
+    </main>
+  );
+}

--- a/src/app/edit/[slug]/revisions/[id]/page.tsx
+++ b/src/app/edit/[slug]/revisions/[id]/page.tsx
@@ -80,31 +80,35 @@ export default async function RevisionDetailPage({ params }: PageProps) {
         >
           &larr; All revisions
         </Link>
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
-          <div className="flex min-w-0 flex-col gap-1.5">
-            <p
-              className="flex flex-wrap items-baseline gap-x-3 gap-y-1 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted [font-variant-numeric:tabular-nums]"
-              title={revision.createdAt.toISOString()}
-            >
-              <span>Revision</span>
-              <span className="normal-case tracking-[0.04em] text-ink">
-                {revision.externalId}
-              </span>
-              <span aria-hidden="true">·</span>
-              <span>{formatDate(revision.createdAt)}</span>
-              {shouldShowSourceLabel(revision.source) ? (
-                <>
-                  <span aria-hidden="true">·</span>
-                  <span>{formatSource(revision.source)}</span>
-                </>
-              ) : null}
-            </p>
-            {revision.summary ? (
-              <p className="text-[0.9375rem] text-ink">{revision.summary}</p>
+        <div className="flex flex-col gap-3">
+          {/* Row 1: revision metadata, full width. */}
+          <p
+            className="flex flex-wrap items-baseline gap-x-3 gap-y-1 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted [font-variant-numeric:tabular-nums]"
+            title={revision.createdAt.toISOString()}
+          >
+            <span>Revision</span>
+            <span className="normal-case tracking-[0.04em] text-ink">
+              {revision.externalId}
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>{formatDate(revision.createdAt)}</span>
+            {shouldShowSourceLabel(revision.source) ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>{formatSource(revision.source)}</span>
+              </>
             ) : null}
-          </div>
-          <div className="sm:shrink-0">
-            <RestoreAction slug={slug} revisionId={revision.externalId} />
+          </p>
+          {/* Row 2: summary on the left, restore action on the right. */}
+          <div className="flex flex-row items-center justify-between gap-4">
+            <p className="min-w-0 flex-1 truncate text-[0.9375rem] text-ink">
+              {revision.summary ?? (
+                <span className="text-muted">(no message)</span>
+              )}
+            </p>
+            <div className="shrink-0">
+              <RestoreAction slug={slug} revisionId={revision.externalId} />
+            </div>
           </div>
         </div>
       </header>

--- a/src/app/edit/[slug]/revisions/[id]/page.tsx
+++ b/src/app/edit/[slug]/revisions/[id]/page.tsx
@@ -5,6 +5,8 @@ import { isEmailAllowed } from "@/lib/access";
 import { getDocBySlug } from "@/lib/db";
 import * as RevisionLog from "@/lib/revision-log";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
+import { FrontmatterDisclosure } from "@/components/frontmatter-disclosure";
+import { parseFrontmatter } from "@/lib/frontmatter";
 import { RestoreAction } from "@/components/restore-action";
 
 type PageProps = {
@@ -64,6 +66,7 @@ export default async function RevisionDetailPage({ params }: PageProps) {
       </main>
     );
   }
+  const { fields: frontmatterFields, body } = parseFrontmatter(revision.content);
 
   return (
     <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
@@ -102,7 +105,8 @@ export default async function RevisionDetailPage({ params }: PageProps) {
       </header>
 
       <article className="prose prose-neutral max-w-none">
-        <MarkdownRenderer content={revision.content} />
+        <FrontmatterDisclosure fields={frontmatterFields} />
+        <MarkdownRenderer content={body} />
       </article>
     </main>
   );

--- a/src/app/edit/[slug]/revisions/[id]/page.tsx
+++ b/src/app/edit/[slug]/revisions/[id]/page.tsx
@@ -80,18 +80,17 @@ export default async function RevisionDetailPage({ params }: PageProps) {
         >
           &larr; All revisions
         </Link>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
           <div className="flex min-w-0 flex-col gap-1.5">
-            <p className="flex items-baseline gap-x-2 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
+            <p
+              className="flex flex-wrap items-baseline gap-x-3 gap-y-1 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted [font-variant-numeric:tabular-nums]"
+              title={revision.createdAt.toISOString()}
+            >
               <span>Revision</span>
               <span className="normal-case tracking-[0.04em] text-ink">
                 {revision.externalId}
               </span>
-            </p>
-            <p
-              className="flex flex-wrap items-baseline gap-x-3 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted [font-variant-numeric:tabular-nums]"
-              title={revision.createdAt.toISOString()}
-            >
+              <span aria-hidden="true">·</span>
               <span>{formatDate(revision.createdAt)}</span>
               {shouldShowSourceLabel(revision.source) ? (
                 <>
@@ -104,7 +103,9 @@ export default async function RevisionDetailPage({ params }: PageProps) {
               <p className="text-[0.9375rem] text-ink">{revision.summary}</p>
             ) : null}
           </div>
-          <RestoreAction slug={slug} revisionId={revision.externalId} />
+          <div className="sm:shrink-0">
+            <RestoreAction slug={slug} revisionId={revision.externalId} />
+          </div>
         </div>
       </header>
 

--- a/src/app/edit/[slug]/revisions/page.tsx
+++ b/src/app/edit/[slug]/revisions/page.tsx
@@ -4,6 +4,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isEmailAllowed } from "@/lib/access";
 import { getDocBySlug } from "@/lib/db";
 import * as RevisionLog from "@/lib/revision-log";
+import { formatSource, shouldShowSourceLabel } from "@/lib/revision-display";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -78,14 +79,23 @@ export default async function RevisionsListPage({ params }: PageProps) {
       </header>
 
       {revisions.length === 0 ? (
-        <p className="mt-12 text-sm text-muted">
-          No revisions yet. Edits to this document will appear here.
-        </p>
+        <div className="mt-12 max-w-prose">
+          <p className="font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
+            No revisions yet
+          </p>
+          <p className="mt-2 text-sm text-muted">
+            Edits to this document will land here. The most recent 50 are kept;
+            older revisions drop off as new ones arrive. Restoring a prior state
+            also creates a new entry, so the audit trail stays linear.
+          </p>
+        </div>
       ) : (
         <ul className="flex flex-col gap-1.5">
           {revisions.map((rev) => {
             const bytes = formatBytes(rev.bytesAdded, rev.bytesRemoved);
             const dateLabel = formatDate(rev.createdAt);
+            const sourceLabel = formatSource(rev.source);
+            const showSource = shouldShowSourceLabel(rev.source);
             const summary = rev.summary ? rev.summary : NO_MESSAGE;
             return (
               <li
@@ -99,17 +109,21 @@ export default async function RevisionsListPage({ params }: PageProps) {
                 >
                   {/* Mobile: stacked. Summary on line 1, meta on line 2. */}
                   <div className="sm:hidden">
-                    <p className="truncate text-[0.9375rem] font-semibold text-ink transition-colors group-hover:text-ochre">
+                    <p className="line-clamp-2 text-[0.9375rem] font-semibold text-ink transition-colors group-hover:text-ochre">
                       {summary}
                     </p>
                     <p className="mt-1 flex flex-wrap items-center gap-x-2 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-muted [font-variant-numeric:tabular-nums]">
                       <span title={rev.createdAt.toISOString()}>{dateLabel}</span>
-                      <span aria-hidden="true">·</span>
-                      <span className="tracking-[0.12em]">{rev.source}</span>
                       {bytes ? (
                         <>
                           <span aria-hidden="true">·</span>
                           <span>{bytes}</span>
+                        </>
+                      ) : null}
+                      {showSource ? (
+                        <>
+                          <span aria-hidden="true">·</span>
+                          <span className="tracking-[0.12em]">{sourceLabel}</span>
                         </>
                       ) : null}
                     </p>
@@ -126,7 +140,7 @@ export default async function RevisionsListPage({ params }: PageProps) {
                       {summary}
                     </span>
                     <span className="font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
-                      {rev.source}
+                      {showSource ? sourceLabel : ""}
                     </span>
                     <span className="min-w-[5rem] text-right font-mono text-[0.6875rem] text-muted [font-variant-numeric:tabular-nums]">
                       {bytes ?? ""}

--- a/src/app/edit/[slug]/revisions/page.tsx
+++ b/src/app/edit/[slug]/revisions/page.tsx
@@ -1,0 +1,143 @@
+import Link from "next/link";
+import { redirect, notFound } from "next/navigation";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { isEmailAllowed } from "@/lib/access";
+import { getDocBySlug } from "@/lib/db";
+import * as RevisionLog from "@/lib/revision-log";
+
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export const metadata = {
+  title: "Revisions",
+  robots: { index: false, follow: false },
+};
+
+const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+const DATE_FORMAT_PRIOR_YEAR = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function formatDate(d: Date): string {
+  const now = new Date();
+  if (d.getFullYear() !== now.getFullYear()) {
+    return DATE_FORMAT_PRIOR_YEAR.format(d).toUpperCase();
+  }
+  return DATE_FORMAT.format(d).toUpperCase().replace(",", "");
+}
+
+function formatBytes(added: number, removed: number): string | null {
+  if (added === 0 && removed === 0) return null;
+  return `+${added} −${removed}`;
+}
+
+const NO_MESSAGE = (
+  <span className="text-muted">(no message)</span>
+);
+
+export default async function RevisionsListPage({ params }: PageProps) {
+  const { user } = await withAuth();
+  if (!user) redirect("/auth");
+  if (!isEmailAllowed(user.email)) redirect("/");
+
+  const { slug } = await params;
+  const doc = await getDocBySlug(slug);
+  if (!doc || doc.ownerId !== user.id) notFound();
+
+  // Retention caps revisions at 50, and the architecture doc treats history
+  // as bounded — request the full retention window so the surface never
+  // hides revisions behind a Show-more button.
+  const { revisions } = await RevisionLog.list(doc.id, { limit: 50 });
+
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 sm:py-12">
+      <header className="mb-6 flex flex-col gap-1">
+        <span className="font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
+          Revisions
+        </span>
+        <h1 className="text-2xl font-bold leading-tight tracking-tight text-ink sm:text-3xl">
+          {doc.title}
+        </h1>
+        <Link
+          href={`/edit/${slug}`}
+          prefetch={false}
+          className="mt-2 self-start font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted transition-colors hover:text-ochre"
+        >
+          &larr; Back to edit
+        </Link>
+      </header>
+
+      {revisions.length === 0 ? (
+        <p className="mt-12 text-sm text-muted">
+          No revisions yet. Edits to this document will appear here.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {revisions.map((rev) => {
+            const bytes = formatBytes(rev.bytesAdded, rev.bytesRemoved);
+            const dateLabel = formatDate(rev.createdAt);
+            const summary = rev.summary ? rev.summary : NO_MESSAGE;
+            return (
+              <li
+                key={rev.externalId}
+                className="rounded-sm border border-border bg-paper-warm"
+              >
+                <Link
+                  href={`/edit/${slug}/revisions/${rev.externalId}`}
+                  prefetch={false}
+                  className="group block px-3.5 py-2.5"
+                >
+                  {/* Mobile: stacked. Summary on line 1, meta on line 2. */}
+                  <div className="sm:hidden">
+                    <p className="truncate text-[0.9375rem] font-semibold text-ink transition-colors group-hover:text-ochre">
+                      {summary}
+                    </p>
+                    <p className="mt-1 flex flex-wrap items-center gap-x-2 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-muted [font-variant-numeric:tabular-nums]">
+                      <span title={rev.createdAt.toISOString()}>{dateLabel}</span>
+                      <span aria-hidden="true">·</span>
+                      <span className="tracking-[0.12em]">{rev.source}</span>
+                      {bytes ? (
+                        <>
+                          <span aria-hidden="true">·</span>
+                          <span>{bytes}</span>
+                        </>
+                      ) : null}
+                    </p>
+                  </div>
+                  {/* Desktop: single dense line. */}
+                  <div className="hidden sm:grid sm:grid-cols-[7rem_1fr_5rem_auto] sm:items-center sm:gap-4">
+                    <span
+                      className="font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.08em] text-muted [font-variant-numeric:tabular-nums]"
+                      title={rev.createdAt.toISOString()}
+                    >
+                      {dateLabel}
+                    </span>
+                    <span className="min-w-0 truncate text-[0.9375rem] font-semibold text-ink transition-colors group-hover:text-ochre">
+                      {summary}
+                    </span>
+                    <span className="font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-muted">
+                      {rev.source}
+                    </span>
+                    <span className="min-w-[5rem] text-right font-mono text-[0.6875rem] text-muted [font-variant-numeric:tabular-nums]">
+                      {bytes ?? ""}
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -835,3 +835,25 @@ button.cmd-palette-row:hover:not([data-selected="true"]) {
 .modal__btn--primary:hover:not(:disabled) {
   background: var(--ochre-deep);
 }
+
+/* Restore-confirm countdown rule. Animates the 2px ochre rule across the
+   bottom of the button as the 3-second countdown elapses. ease-out-quart
+   makes the chance to cancel feel like it's slipping away. */
+[data-restore-confirm-rule] {
+  animation: restore-confirm-rule 3000ms cubic-bezier(0.165, 0.84, 0.44, 1)
+    forwards;
+}
+@keyframes restore-confirm-rule {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-restore-confirm-rule] {
+    animation: none;
+    transform: scaleX(1);
+  }
+}

--- a/src/components/delete-button.tsx
+++ b/src/components/delete-button.tsx
@@ -42,7 +42,7 @@ export function DeleteButton({ slug, title }: { slug: string; title: string }) {
       onClick={onClick}
       disabled={busy || isPending}
       aria-label={`Delete ${title}`}
-      title={`Delete ${title}`}
+      title="Delete"
       className="cursor-pointer rounded p-1 text-muted transition-colors hover:bg-paper hover:text-ochre disabled:opacity-50"
     >
       <svg

--- a/src/components/doc-list.tsx
+++ b/src/components/doc-list.tsx
@@ -23,7 +23,6 @@ const TOOLTIP_DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
 
 export async function DocList({ ownerId }: { ownerId: string }) {
   const { docs } = await listDocs({ ownerId, limit: 20 });
-  const revisionCounts = await RevisionLog.countByDoc(docs.map((d) => d.id));
 
   if (docs.length === 0) {
     return (
@@ -32,6 +31,8 @@ export async function DocList({ ownerId }: { ownerId: string }) {
       </p>
     );
   }
+
+  const revisionCounts = await RevisionLog.countByDoc(docs.map((d) => d.id));
 
   return (
     <ul className="flex flex-col gap-1.5">

--- a/src/components/doc-list.tsx
+++ b/src/components/doc-list.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { listDocs } from "@/lib/db";
+import * as RevisionLog from "@/lib/revision-log";
 import { DeleteButton } from "@/components/delete-button";
 import { EditLink } from "@/components/edit-link";
 import { HistoryLink } from "@/components/history-link";
@@ -13,6 +14,7 @@ const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
 
 export async function DocList({ ownerId }: { ownerId: string }) {
   const { docs } = await listDocs({ ownerId, limit: 20 });
+  const revisionCounts = await RevisionLog.countByDoc(docs.map((d) => d.id));
 
   if (docs.length === 0) {
     return (
@@ -40,7 +42,11 @@ export async function DocList({ ownerId }: { ownerId: string }) {
             {DATE_FORMAT.format(doc.createdAt)}
           </span>
           <span className="hidden items-center gap-1 md:flex">
-            <HistoryLink slug={doc.slug} title={doc.title} />
+            <HistoryLink
+              slug={doc.slug}
+              title={doc.title}
+              revisionCount={revisionCounts[doc.id] ?? 0}
+            />
             <EditLink slug={doc.slug} title={doc.title} />
             <DeleteButton slug={doc.slug} title={doc.title} />
           </span>

--- a/src/components/doc-list.tsx
+++ b/src/components/doc-list.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { listDocs } from "@/lib/db";
 import { DeleteButton } from "@/components/delete-button";
 import { EditLink } from "@/components/edit-link";
+import { HistoryLink } from "@/components/history-link";
 import { RowKebabMenu } from "@/components/row-kebab-menu";
 
 const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
@@ -39,6 +40,7 @@ export async function DocList({ ownerId }: { ownerId: string }) {
             {DATE_FORMAT.format(doc.createdAt)}
           </span>
           <span className="hidden items-center gap-1 md:flex">
+            <HistoryLink slug={doc.slug} title={doc.title} />
             <EditLink slug={doc.slug} title={doc.title} />
             <DeleteButton slug={doc.slug} title={doc.title} />
           </span>

--- a/src/components/doc-list.tsx
+++ b/src/components/doc-list.tsx
@@ -12,6 +12,15 @@ const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
   day: "2-digit",
 });
 
+const TOOLTIP_DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
 export async function DocList({ ownerId }: { ownerId: string }) {
   const { docs } = await listDocs({ ownerId, limit: 20 });
   const revisionCounts = await RevisionLog.countByDoc(docs.map((d) => d.id));
@@ -38,8 +47,11 @@ export async function DocList({ ownerId }: { ownerId: string }) {
           >
             {doc.title}
           </Link>
-          <span className="font-mono text-xs text-muted [font-variant-numeric:tabular-nums]">
-            {DATE_FORMAT.format(doc.createdAt)}
+          <span
+            className="font-mono text-xs text-muted [font-variant-numeric:tabular-nums]"
+            title={`Last updated ${TOOLTIP_DATE_FORMAT.format(doc.updatedAt).toUpperCase().replace(",", "")}`}
+          >
+            {DATE_FORMAT.format(doc.updatedAt)}
           </span>
           <span className="hidden items-center gap-1 md:flex">
             <HistoryLink

--- a/src/components/edit-link.test.tsx
+++ b/src/components/edit-link.test.tsx
@@ -1,0 +1,13 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EditLink } from "./edit-link";
+
+describe("EditLink", () => {
+  it("renders an accessible link to the doc's edit route", () => {
+    render(<EditLink slug="abc123" title="Sample doc" />);
+    const link = screen.getByRole("link", { name: /edit sample doc/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/edit/abc123");
+  });
+});

--- a/src/components/edit-link.tsx
+++ b/src/components/edit-link.tsx
@@ -5,6 +5,7 @@ export function EditLink({ slug, title }: { slug: string; title: string }) {
     <Link
       href={`/edit/${slug}`}
       aria-label={`Edit ${title}`}
+      title="Edit"
       prefetch={false}
       className="cursor-pointer rounded p-1 text-muted transition-colors hover:bg-paper hover:text-ochre"
     >

--- a/src/components/history-link.tsx
+++ b/src/components/history-link.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+export function HistoryLink({ slug, title }: { slug: string; title: string }) {
+  return (
+    <Link
+      href={`/edit/${slug}/revisions`}
+      aria-label={`History for ${title}`}
+      prefetch={false}
+      className="cursor-pointer rounded p-1 text-muted transition-colors hover:bg-paper hover:text-ochre"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-4 w-4"
+        aria-hidden="true"
+      >
+        <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+        <path d="M3 3v5h5" />
+        <path d="M12 7v5l3 2" />
+      </svg>
+    </Link>
+  );
+}

--- a/src/components/history-link.tsx
+++ b/src/components/history-link.tsx
@@ -1,10 +1,23 @@
 import Link from "next/link";
 
-export function HistoryLink({ slug, title }: { slug: string; title: string }) {
+type Props = {
+  slug: string;
+  title: string;
+  revisionCount: number;
+};
+
+export function HistoryLink({ slug, title, revisionCount }: Props) {
+  const tooltip =
+    revisionCount === 0
+      ? "Revisions"
+      : revisionCount === 1
+        ? "Revisions (1)"
+        : `Revisions (${revisionCount})`;
   return (
     <Link
       href={`/edit/${slug}/revisions`}
-      aria-label={`History for ${title}`}
+      aria-label={`Revisions for ${title}`}
+      title={tooltip}
       prefetch={false}
       className="cursor-pointer rounded p-1 text-muted transition-colors hover:bg-paper hover:text-ochre"
     >

--- a/src/components/restore-action.tsx
+++ b/src/components/restore-action.tsx
@@ -44,7 +44,7 @@ export function RestoreAction({ slug, revisionId }: Props) {
   }
 
   return (
-    <div className="flex flex-col items-start gap-2 sm:items-end">
+    <div className="flex flex-col items-end gap-2">
       <RestoreButton onConfirm={onConfirm} disabled={busy} />
       {error ? (
         <p

--- a/src/components/restore-action.tsx
+++ b/src/components/restore-action.tsx
@@ -44,17 +44,17 @@ export function RestoreAction({ slug, revisionId }: Props) {
   }
 
   return (
-    <div className="flex flex-col items-end gap-2">
+    <div className="flex flex-col items-start gap-2 sm:items-end">
       <RestoreButton onConfirm={onConfirm} disabled={busy} />
       {error ? (
         <p
           role="alert"
-          className="flex items-baseline gap-x-2 font-mono text-[0.75rem] font-semibold text-ink"
+          className="flex items-baseline gap-x-2 text-sm text-ink"
         >
-          <span className="text-[0.6875rem] uppercase tracking-[0.12em] text-ochre">
+          <span className="font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-ochre">
             Restore failed
           </span>
-          <span className="font-sans font-normal text-ink">{error}</span>
+          <span>{error}</span>
         </p>
       ) : null}
     </div>

--- a/src/components/restore-action.tsx
+++ b/src/components/restore-action.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { RestoreButton } from "./restore-button";
+
+type Props = {
+  slug: string;
+  revisionId: string;
+};
+
+export function RestoreAction({ slug, revisionId }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onConfirm() {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/docs/${slug}/restore`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ revisionId }),
+      });
+      if (!response.ok) {
+        let message = "Restore failed. Try again.";
+        try {
+          const data = (await response.json()) as { error?: string };
+          if (data?.error) message = data.error;
+        } catch {
+          // ignore parse failure
+        }
+        setError(message);
+        return;
+      }
+      router.push(`/v/${slug}`);
+    } catch {
+      setError("Restore failed. Try again.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <RestoreButton onConfirm={onConfirm} disabled={busy} />
+      {error ? (
+        <p
+          role="alert"
+          className="text-[0.75rem] text-muted"
+        >
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/restore-action.tsx
+++ b/src/components/restore-action.tsx
@@ -25,7 +25,7 @@ export function RestoreAction({ slug, revisionId }: Props) {
         body: JSON.stringify({ revisionId }),
       });
       if (!response.ok) {
-        let message = "Restore failed. Try again.";
+        let message = "Try again.";
         try {
           const data = (await response.json()) as { error?: string };
           if (data?.error) message = data.error;
@@ -35,9 +35,9 @@ export function RestoreAction({ slug, revisionId }: Props) {
         setError(message);
         return;
       }
-      router.push(`/v/${slug}`);
+      router.push(`/edit/${slug}`);
     } catch {
-      setError("Restore failed. Try again.");
+      setError("Try again.");
     } finally {
       setBusy(false);
     }
@@ -49,9 +49,12 @@ export function RestoreAction({ slug, revisionId }: Props) {
       {error ? (
         <p
           role="alert"
-          className="text-[0.75rem] text-muted"
+          className="flex items-baseline gap-x-2 font-mono text-[0.75rem] font-semibold text-ink"
         >
-          {error}
+          <span className="text-[0.6875rem] uppercase tracking-[0.12em] text-ochre">
+            Restore failed
+          </span>
+          <span className="font-sans font-normal text-ink">{error}</span>
         </p>
       ) : null}
     </div>

--- a/src/components/restore-button.test.tsx
+++ b/src/components/restore-button.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { RestoreButton } from "./restore-button";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe("RestoreButton", () => {
+  it("renders the rest label", () => {
+    render(<RestoreButton onConfirm={() => {}} />);
+    expect(
+      screen.getByRole("button", { name: /restore this version/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("on first click, swaps to the confirm label with a 3-second countdown", () => {
+    render(<RestoreButton onConfirm={() => {}} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(
+      screen.getByRole("button", { name: /confirm restore \(3\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onConfirm only on the second click while in the confirming phase", () => {
+    const onConfirm = vi.fn();
+    render(<RestoreButton onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onConfirm).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("ticks the countdown down each second", () => {
+    render(<RestoreButton onConfirm={() => {}} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("button")).toHaveTextContent(/\(3\)/);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByRole("button")).toHaveTextContent(/\(2\)/);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByRole("button")).toHaveTextContent(/\(1\)/);
+  });
+
+  it("reverts to the rest label after the countdown lapses", () => {
+    const onConfirm = vi.fn();
+    render(<RestoreButton onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button"));
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(
+      screen.getByRole("button", { name: /restore this version/i }),
+    ).toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/restore-button.tsx
+++ b/src/components/restore-button.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useReducer } from "react";
+import { initial, reduce } from "@/lib/restore-confirm-state";
+
+type Props = {
+  onConfirm: () => void;
+  disabled?: boolean;
+};
+
+export function RestoreButton({ onConfirm, disabled }: Props) {
+  const [state, dispatch] = useReducer(reduce, initial);
+
+  useEffect(() => {
+    if (state.phase !== "confirming") return;
+    const id = setInterval(() => dispatch({ type: "tick" }), 1000);
+    return () => clearInterval(id);
+  }, [state.phase]);
+
+  const label =
+    state.phase === "idle"
+      ? "Restore this version"
+      : `Confirm restore (${state.secondsLeft})`;
+
+  function handleClick() {
+    if (disabled) return;
+    if (state.phase === "confirming") {
+      onConfirm();
+      return;
+    }
+    dispatch({ type: "click" });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      data-phase={state.phase}
+      aria-live="polite"
+      className="relative cursor-pointer overflow-hidden rounded-md border border-border bg-transparent px-3 py-1.5 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-ink transition-colors hover:bg-paper-warm hover:text-ochre disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {label}
+      {state.phase === "confirming" && (
+        <span
+          aria-hidden="true"
+          data-restore-confirm-rule
+          className="absolute bottom-0 left-0 h-[2px] w-full origin-left bg-ochre"
+        />
+      )}
+    </button>
+  );
+}

--- a/src/components/restore-button.tsx
+++ b/src/components/restore-button.tsx
@@ -32,22 +32,31 @@ export function RestoreButton({ onConfirm, disabled }: Props) {
   }
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={disabled}
-      data-phase={state.phase}
-      aria-live="polite"
-      className="relative cursor-pointer overflow-hidden rounded-md border border-border bg-transparent px-3 py-1.5 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-ink transition-colors hover:bg-paper-warm hover:text-ochre disabled:cursor-not-allowed disabled:opacity-50"
-    >
-      {label}
-      {state.phase === "confirming" && (
-        <span
-          aria-hidden="true"
-          data-restore-confirm-rule
-          className="absolute bottom-0 left-0 h-[2px] w-full origin-left bg-ochre"
-        />
-      )}
-    </button>
+    <>
+      {/* Dedicated live region so AT announcements are reliable across NVDA,
+          VoiceOver, and JAWS. aria-live on a <button> has inconsistent
+          behavior in older AT versions. */}
+      <span aria-live="polite" aria-atomic="true" className="sr-only">
+        {state.phase === "confirming"
+          ? `Confirm restore in ${state.secondsLeft} seconds`
+          : ""}
+      </span>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled}
+        data-phase={state.phase}
+        className="relative cursor-pointer overflow-hidden rounded-md border border-border bg-transparent px-3 py-1.5 font-mono text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-ink transition-colors hover:bg-paper-warm hover:text-ochre disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {label}
+        {state.phase === "confirming" && (
+          <span
+            aria-hidden="true"
+            data-restore-confirm-rule
+            className="absolute bottom-0 left-0 h-[2px] w-full origin-left bg-ochre"
+          />
+        )}
+      </button>
+    </>
   );
 }

--- a/src/components/row-kebab-menu.tsx
+++ b/src/components/row-kebab-menu.tsx
@@ -91,6 +91,16 @@ export function RowKebabMenu({ slug, title }: { slug: string; title: string }) {
             <EditIcon />
             <span>Edit</span>
           </Link>
+          <Link
+            href={`/edit/${slug}/revisions`}
+            role="menuitem"
+            prefetch={false}
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2.5 border-t border-border px-3 py-2.5 text-sm text-ink transition-colors hover:bg-paper-warm"
+          >
+            <HistoryIcon />
+            <span>History</span>
+          </Link>
           <button
             type="button"
             role="menuitem"
@@ -148,6 +158,16 @@ function DeleteIcon() {
       <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
       <path d="M10 11v6" />
       <path d="M14 11v6" />
+    </svg>
+  );
+}
+
+function HistoryIcon() {
+  return (
+    <svg {...strokeProps()}>
+      <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+      <path d="M3 3v5h5" />
+      <path d="M12 7v5l3 2" />
     </svg>
   );
 }

--- a/src/lib/diff-stats.test.ts
+++ b/src/lib/diff-stats.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { computeDiff } from "./diff-stats";
+
+describe("computeDiff", () => {
+  it("returns zero deltas for identical strings", () => {
+    expect(computeDiff("hello", "hello")).toEqual({
+      bytesAdded: 0,
+      bytesRemoved: 0,
+    });
+  });
+
+  it("returns zero deltas for two empty strings", () => {
+    expect(computeDiff("", "")).toEqual({ bytesAdded: 0, bytesRemoved: 0 });
+  });
+
+  it("counts bytes added when content grows from empty", () => {
+    expect(computeDiff("", "hello")).toEqual({
+      bytesAdded: 5,
+      bytesRemoved: 0,
+    });
+  });
+
+  it("counts bytes removed when content shrinks to empty", () => {
+    expect(computeDiff("hello", "")).toEqual({
+      bytesAdded: 0,
+      bytesRemoved: 5,
+    });
+  });
+
+  it("counts both sides of a substitution", () => {
+    // "hello" → "world" share an "o" and "l", so the diff algorithm reports
+    // smaller counts than 5/5. The point is that both sides are non-zero.
+    const stats = computeDiff("hello", "world");
+    expect(stats.bytesAdded).toBeGreaterThan(0);
+    expect(stats.bytesRemoved).toBeGreaterThan(0);
+    expect(stats.bytesAdded).toBeLessThanOrEqual(5);
+    expect(stats.bytesRemoved).toBeLessThanOrEqual(5);
+  });
+
+  it("counts only the changed portion when the rest matches", () => {
+    // " world" is shared; "hello" becomes "howdy".
+    const stats = computeDiff("hello world", "howdy world");
+    expect(stats.bytesAdded).toBeGreaterThan(0);
+    expect(stats.bytesRemoved).toBeGreaterThan(0);
+    // The unchanged " world" (6 bytes) should not be counted on either side.
+    expect(stats.bytesAdded).toBeLessThanOrEqual(5);
+    expect(stats.bytesRemoved).toBeLessThanOrEqual(5);
+  });
+
+  it("counts UTF-8 byte length, not code unit length, for multibyte chars", () => {
+    // "café" → bytes_added should be 5 (c=1, a=1, f=1, é=2), not 4.
+    const stats = computeDiff("", "café");
+    expect(stats.bytesAdded).toBe(5);
+  });
+
+  it("counts emoji as their full UTF-8 byte length", () => {
+    // "🚀" is a single user-perceived char, 4 UTF-8 bytes.
+    const stats = computeDiff("", "🚀");
+    expect(stats.bytesAdded).toBe(4);
+  });
+
+  it("handles a typical markdown edit", () => {
+    const before = "# Title\n\nSome text here.\n";
+    const after = "# Title\n\nSome updated text here.\n";
+    // The unchanged prefix and suffix should not inflate either count.
+    const stats = computeDiff(before, after);
+    expect(stats.bytesAdded).toBe(8); // "updated "
+    expect(stats.bytesRemoved).toBe(0);
+  });
+});

--- a/src/lib/diff-stats.ts
+++ b/src/lib/diff-stats.ts
@@ -1,0 +1,24 @@
+import { diffChars } from "diff";
+
+export type DiffStats = {
+  bytesAdded: number;
+  bytesRemoved: number;
+};
+
+export function computeDiff(prev: string, next: string): DiffStats {
+  if (prev === next) {
+    return { bytesAdded: 0, bytesRemoved: 0 };
+  }
+
+  const changes = diffChars(prev, next);
+  let bytesAdded = 0;
+  let bytesRemoved = 0;
+  for (const change of changes) {
+    if (change.added) {
+      bytesAdded += Buffer.byteLength(change.value, "utf8");
+    } else if (change.removed) {
+      bytesRemoved += Buffer.byteLength(change.value, "utf8");
+    }
+  }
+  return { bytesAdded, bytesRemoved };
+}

--- a/src/lib/doc-mutation-path.test.ts
+++ b/src/lib/doc-mutation-path.test.ts
@@ -31,6 +31,24 @@ afterAll(async () => {
   await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
 });
 
+describe("DocMutationPath.writeDocContent — return shape", () => {
+  it("returns the updated doc so callers don't need a second query", async () => {
+    const doc = await createTestDoc("v0");
+    const result = await DocMutationPath.writeDocContent({
+      docId: doc.id,
+      newContent: "v1",
+      newTitle: "Renamed",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    expect(result.doc.content).toBe("v1");
+    expect(result.doc.title).toBe("Renamed");
+    expect(result.doc.id).toBe(doc.id);
+    expect(result.doc.slug).toBe(doc.slug);
+  });
+});
+
 describe("DocMutationPath.writeDocContent — atomicity", () => {
   it("rolls back the docs UPDATE if RevisionLog.record throws", async () => {
     const doc = await createTestDoc("v0");

--- a/src/lib/doc-mutation-path.test.ts
+++ b/src/lib/doc-mutation-path.test.ts
@@ -122,3 +122,49 @@ describe("DocMutationPath.writeDocContent", () => {
     expect(revision?.source).toBe("manual");
   });
 });
+
+describe("DocMutationPath.writeDocContent — concurrent writers", () => {
+  it("serializes via FOR UPDATE so each revision snapshots the immediate prior state", async () => {
+    // Two writers race against the same doc. With row-level locking, the
+    // second to acquire the lock reads the first's committed content as its
+    // prevContent. Regardless of which writer wins the race, the resulting
+    // revisions form a deterministic invariant: the set of snapshotted
+    // contents is exactly { original, intermediate }, and persisted.content
+    // matches whichever writer committed second.
+    const doc = await createTestDoc("v0");
+
+    const [resultA, resultB] = await Promise.all([
+      DocMutationPath.writeDocContent({
+        docId: doc.id,
+        newContent: "vA",
+        summary: "writer A",
+        source: "manual",
+        ownerId: TEST_OWNER,
+      }),
+      DocMutationPath.writeDocContent({
+        docId: doc.id,
+        newContent: "vB",
+        summary: "writer B",
+        source: "manual",
+        ownerId: TEST_OWNER,
+      }),
+    ]);
+
+    // The persisted content matches whichever writer committed last.
+    const persisted = await getDocBySlug(doc.slug);
+    expect(["vA", "vB"]).toContain(persisted?.content);
+
+    // Two revisions exist. As a set, their contents capture the original
+    // ("v0") plus the intermediate (the loser's newContent).
+    const revA = await RevisionLog.get(doc.id, resultA.revisionId);
+    const revB = await RevisionLog.get(doc.id, resultB.revisionId);
+    expect(revA).not.toBeNull();
+    expect(revB).not.toBeNull();
+    const snapshotted = new Set([revA!.content, revB!.content]);
+    expect(snapshotted.has("v0")).toBe(true);
+    // The other snapshot is the loser's newContent (i.e., the one whose
+    // committed state became the intermediate prevContent for the winner).
+    const intermediate = persisted?.content === "vA" ? "vB" : "vA";
+    expect(snapshotted.has(intermediate)).toBe(true);
+  });
+});

--- a/src/lib/doc-mutation-path.test.ts
+++ b/src/lib/doc-mutation-path.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { sql } from "@vercel/postgres";
+import { getDocBySlug, insertDoc, type Doc } from "./db";
+import { generateSlug } from "./slug";
+import { stripMarkdown } from "./strip-md";
+import * as RevisionLog from "./revision-log";
+import * as DocMutationPath from "./doc-mutation-path";
+
+const TEST_OWNER = "__test_doc_mutation_path__";
+
+async function createTestDoc(content: string): Promise<Doc> {
+  return insertDoc({
+    slug: generateSlug(),
+    ownerId: TEST_OWNER,
+    title: "Test",
+    content,
+    kind: null,
+    searchText: stripMarkdown(content),
+  });
+}
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error(
+      "POSTGRES_URL not set — DocMutationPath integration tests need .env.local.",
+    );
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+});
+
+describe("DocMutationPath.writeDocContent — atomicity", () => {
+  it("rolls back the docs UPDATE if RevisionLog.record throws", async () => {
+    const doc = await createTestDoc("v0");
+
+    const spy = vi
+      .spyOn(RevisionLog, "record")
+      .mockRejectedValueOnce(new Error("boom"));
+
+    await expect(
+      DocMutationPath.writeDocContent({
+        docId: doc.id,
+        newContent: "v1",
+        summary: null,
+        source: "manual",
+        ownerId: TEST_OWNER,
+      }),
+    ).rejects.toThrow("boom");
+
+    spy.mockRestore();
+
+    const persisted = await getDocBySlug(doc.slug);
+    expect(persisted?.content).toBe("v0");
+  });
+});
+
+describe("DocMutationPath.writeDocContent — metadata", () => {
+  it("persists optional title, searchText, and kind on the doc row", async () => {
+    const doc = await createTestDoc("v0");
+
+    await DocMutationPath.writeDocContent({
+      docId: doc.id,
+      newContent: "v1",
+      newTitle: "Renamed",
+      newSearchText: "renamed search text",
+      newKind: "note",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+
+    const persisted = await getDocBySlug(doc.slug);
+    expect(persisted?.content).toBe("v1");
+    expect(persisted?.title).toBe("Renamed");
+    expect(persisted?.searchText).toBe("renamed search text");
+    expect(persisted?.kind).toBe("note");
+  });
+});
+
+describe("DocMutationPath.writeDocContent", () => {
+  it("updates doc content and records a revision capturing the previous content", async () => {
+    const doc = await createTestDoc("# Original\n\nbody");
+
+    const result = await DocMutationPath.writeDocContent({
+      docId: doc.id,
+      newContent: "# Updated\n\nbody",
+      summary: "Title rename",
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+
+    // Doc row reflects the new content.
+    const persisted = await getDocBySlug(doc.slug);
+    expect(persisted?.content).toBe("# Updated\n\nbody");
+
+    // The returned revision is retrievable and snapshots the *previous* content.
+    expect(result.revisionId).toMatch(/^rv_/);
+    const revision = await RevisionLog.get(doc.id, result.revisionId);
+    expect(revision).not.toBeNull();
+    expect(revision?.content).toBe("# Original\n\nbody");
+    expect(revision?.summary).toBe("Title rename");
+    expect(revision?.source).toBe("manual");
+  });
+});

--- a/src/lib/doc-mutation-path.ts
+++ b/src/lib/doc-mutation-path.ts
@@ -1,0 +1,77 @@
+import { db } from "@vercel/postgres";
+import * as RevisionLog from "./revision-log";
+
+export type WriteDocContentInput = {
+  docId: string;
+  newContent: string;
+  newTitle?: string;
+  newSearchText?: string;
+  newKind?: string | null;
+  summary: string | null;
+  source: RevisionLog.RevisionSource;
+  ownerId: string;
+};
+
+export type WriteDocContentResult = {
+  revisionId: string;
+};
+
+export async function writeDocContent(
+  input: WriteDocContentInput,
+): Promise<WriteDocContentResult> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+
+    const prevResult = await client.query<{ content: string }>(
+      `SELECT content FROM docs WHERE id = $1`,
+      [input.docId],
+    );
+    const prev = prevResult.rows[0];
+    if (!prev) {
+      throw new Error(`docs row not found for id=${input.docId}`);
+    }
+
+    const sets: string[] = ["content = $1"];
+    const values: unknown[] = [input.newContent];
+    function bind(value: unknown): string {
+      values.push(value);
+      return `$${values.length}`;
+    }
+    if (input.newTitle !== undefined) {
+      sets.push(`title = ${bind(input.newTitle)}`);
+    }
+    if (input.newSearchText !== undefined) {
+      sets.push(`search_text = ${bind(input.newSearchText)}`);
+    }
+    if (input.newKind !== undefined) {
+      sets.push(`kind = ${bind(input.newKind)}`);
+    }
+    sets.push(`updated_at = now()`);
+    const docIdParam = bind(input.docId);
+    await client.query(
+      `UPDATE docs SET ${sets.join(", ")} WHERE id = ${docIdParam}`,
+      values,
+    );
+
+    const revision = await RevisionLog.record(
+      {
+        docId: input.docId,
+        prevContent: prev.content,
+        nextContent: input.newContent,
+        summary: input.summary,
+        source: input.source,
+        ownerId: input.ownerId,
+      },
+      client,
+    );
+
+    await client.query("COMMIT");
+    return { revisionId: revision.externalId };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/src/lib/doc-mutation-path.ts
+++ b/src/lib/doc-mutation-path.ts
@@ -1,4 +1,5 @@
 import { db } from "@vercel/postgres";
+import type { Doc } from "./db";
 import * as RevisionLog from "./revision-log";
 
 export type WriteDocContentInput = {
@@ -13,8 +14,35 @@ export type WriteDocContentInput = {
 };
 
 export type WriteDocContentResult = {
+  doc: Doc;
   revisionId: string;
 };
+
+type DocRow = {
+  id: string;
+  slug: string;
+  owner_id: string;
+  title: string | null;
+  content: string;
+  kind: string | null;
+  search_text: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+function rowToDoc(row: DocRow): Doc {
+  return {
+    id: row.id,
+    slug: row.slug,
+    ownerId: row.owner_id,
+    title: row.title ?? "Untitled",
+    content: row.content,
+    kind: row.kind,
+    searchText: row.search_text,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
 
 export async function writeDocContent(
   input: WriteDocContentInput,
@@ -49,10 +77,16 @@ export async function writeDocContent(
     }
     sets.push(`updated_at = now()`);
     const docIdParam = bind(input.docId);
-    await client.query(
-      `UPDATE docs SET ${sets.join(", ")} WHERE id = ${docIdParam}`,
+    const updateResult = await client.query<DocRow>(
+      `UPDATE docs SET ${sets.join(", ")} WHERE id = ${docIdParam}
+       RETURNING id, slug, owner_id, title, content, kind, search_text,
+                 created_at, updated_at`,
       values,
     );
+    const updatedRow = updateResult.rows[0];
+    if (!updatedRow) {
+      throw new Error(`docs UPDATE returned no rows for id=${input.docId}`);
+    }
 
     const revision = await RevisionLog.record(
       {
@@ -67,7 +101,7 @@ export async function writeDocContent(
     );
 
     await client.query("COMMIT");
-    return { revisionId: revision.externalId };
+    return { doc: rowToDoc(updatedRow), revisionId: revision.externalId };
   } catch (err) {
     await client.query("ROLLBACK");
     throw err;

--- a/src/lib/doc-mutation-path.ts
+++ b/src/lib/doc-mutation-path.ts
@@ -51,8 +51,12 @@ export async function writeDocContent(
   try {
     await client.query("BEGIN");
 
+    // Lock the docs row so two concurrent writers serialize. Without FOR
+    // UPDATE, both writers can read the same prevContent and the second
+    // revision would snapshot stale content instead of the actual immediate
+    // prior state.
     const prevResult = await client.query<{ content: string }>(
-      `SELECT content FROM docs WHERE id = $1`,
+      `SELECT content FROM docs WHERE id = $1 FOR UPDATE`,
       [input.docId],
     );
     const prev = prevResult.rows[0];

--- a/src/lib/restore-confirm-state.test.ts
+++ b/src/lib/restore-confirm-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { initial, reduce, type State } from "./restore-confirm-state";
+
+describe("restore-confirm-state — initial", () => {
+  it("starts in the idle phase", () => {
+    expect(initial).toEqual({ phase: "idle" });
+  });
+});
+
+describe("restore-confirm-state — click from idle", () => {
+  it("enters the confirming phase with 3 seconds remaining", () => {
+    expect(reduce(initial, { type: "click" })).toEqual({
+      phase: "confirming",
+      secondsLeft: 3,
+    });
+  });
+});
+
+describe("restore-confirm-state — tick during countdown", () => {
+  it("decrements secondsLeft", () => {
+    const state: State = { phase: "confirming", secondsLeft: 3 };
+    expect(reduce(state, { type: "tick" })).toEqual({
+      phase: "confirming",
+      secondsLeft: 2,
+    });
+  });
+
+  it("reverts to idle when the countdown reaches zero", () => {
+    const state: State = { phase: "confirming", secondsLeft: 1 };
+    expect(reduce(state, { type: "tick" })).toEqual({ phase: "idle" });
+  });
+});
+
+describe("restore-confirm-state — cancel", () => {
+  it("returns to idle from confirming", () => {
+    const state: State = { phase: "confirming", secondsLeft: 2 };
+    expect(reduce(state, { type: "cancel" })).toEqual({ phase: "idle" });
+  });
+
+  it("is a no-op from idle", () => {
+    expect(reduce(initial, { type: "cancel" })).toEqual({ phase: "idle" });
+  });
+});
+
+describe("restore-confirm-state — second click while confirming", () => {
+  it("is a no-op for the reducer; the consumer detects the click and commits", () => {
+    const state: State = { phase: "confirming", secondsLeft: 2 };
+    expect(reduce(state, { type: "click" })).toBe(state);
+  });
+});

--- a/src/lib/restore-confirm-state.ts
+++ b/src/lib/restore-confirm-state.ts
@@ -1,0 +1,21 @@
+export type State = { phase: "idle" } | { phase: "confirming"; secondsLeft: number };
+
+export type Event = { type: "click" } | { type: "tick" } | { type: "cancel" };
+
+export const initial: State = { phase: "idle" };
+
+const COUNTDOWN_SECONDS = 3;
+
+export function reduce(state: State, event: Event): State {
+  if (state.phase === "idle" && event.type === "click") {
+    return { phase: "confirming", secondsLeft: COUNTDOWN_SECONDS };
+  }
+  if (state.phase === "confirming" && event.type === "tick") {
+    if (state.secondsLeft <= 1) return { phase: "idle" };
+    return { phase: "confirming", secondsLeft: state.secondsLeft - 1 };
+  }
+  if (state.phase === "confirming" && event.type === "cancel") {
+    return { phase: "idle" };
+  }
+  return state;
+}

--- a/src/lib/revision-display.test.ts
+++ b/src/lib/revision-display.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { formatSource, shouldShowSourceLabel } from "./revision-display";
+
+describe("formatSource", () => {
+  it("maps the four source enum values to user-facing labels", () => {
+    expect(formatSource("manual")).toBe("Edit");
+    expect(formatSource("cli")).toBe("API");
+    expect(formatSource("agent")).toBe("Agent");
+    expect(formatSource("restore")).toBe("Restored");
+  });
+});
+
+describe("shouldShowSourceLabel", () => {
+  it("hides the source label on restore rows since the summary already says 'Restored from rv_…'", () => {
+    expect(shouldShowSourceLabel("restore")).toBe(false);
+  });
+
+  it("shows the source label on every other source", () => {
+    expect(shouldShowSourceLabel("manual")).toBe(true);
+    expect(shouldShowSourceLabel("cli")).toBe(true);
+    expect(shouldShowSourceLabel("agent")).toBe(true);
+  });
+});

--- a/src/lib/revision-display.ts
+++ b/src/lib/revision-display.ts
@@ -1,0 +1,16 @@
+import type { RevisionSource } from "./revision-log";
+
+const SOURCE_LABELS: Record<RevisionSource, string> = {
+  manual: "Edit",
+  cli: "API",
+  agent: "Agent",
+  restore: "Restored",
+};
+
+export function formatSource(source: RevisionSource): string {
+  return SOURCE_LABELS[source];
+}
+
+export function shouldShowSourceLabel(source: RevisionSource): boolean {
+  return source !== "restore";
+}

--- a/src/lib/revision-log.test.ts
+++ b/src/lib/revision-log.test.ts
@@ -32,12 +32,15 @@ afterAll(async () => {
 });
 
 describe("RevisionLog.record + get round-trip", () => {
-  it("persists a revision and returns it via get(docId, externalId)", async () => {
+  it("snapshots the prior content so a future restore can recover this state", async () => {
+    // The revision row preserves prevContent (the state being superseded), not
+    // nextContent. This is the chokepoint property: every prior state captured
+    // before it stops being current.
     const doc = await createTestDoc("# Original\n\nbody");
     const result = await RevisionLog.record({
       docId: doc.id,
-      content: "# Updated\n\nbody",
       prevContent: doc.content,
+      nextContent: "# Updated\n\nbody",
       summary: "Title bump",
       source: "manual",
       ownerId: TEST_OWNER,
@@ -51,7 +54,7 @@ describe("RevisionLog.record + get round-trip", () => {
     expect(fetched).toMatchObject({
       externalId: result.externalId,
       docId: doc.id,
-      content: "# Updated\n\nbody",
+      content: "# Original\n\nbody", // prior state snapshotted
       summary: "Title bump",
       source: "manual",
       createdBy: TEST_OWNER,
@@ -68,8 +71,8 @@ describe("RevisionLog transactional client", () => {
       await RevisionLog.record(
         {
           docId: doc.id,
-          content: "v1",
           prevContent: "v0",
+          nextContent: "v1",
           summary: "rolled back",
           source: "manual",
           ownerId: TEST_OWNER,
@@ -91,8 +94,8 @@ describe("RevisionLog byte counts", () => {
     const doc = await createTestDoc("hello world");
     await RevisionLog.record({
       docId: doc.id,
-      content: "hello universe",
       prevContent: "hello world",
+      nextContent: "hello universe",
       summary: null,
       source: "manual",
       ownerId: TEST_OWNER,
@@ -114,24 +117,24 @@ describe("RevisionLog.list", () => {
     const doc = await createTestDoc("v0");
     const r1 = await RevisionLog.record({
       docId: doc.id,
-      content: "v1",
       prevContent: "v0",
+      nextContent: "v1",
       summary: "first",
       source: "manual",
       ownerId: TEST_OWNER,
     });
     const r2 = await RevisionLog.record({
       docId: doc.id,
-      content: "v2",
       prevContent: "v1",
+      nextContent: "v2",
       summary: "second",
       source: "manual",
       ownerId: TEST_OWNER,
     });
     const r3 = await RevisionLog.record({
       docId: doc.id,
-      content: "v3",
       prevContent: "v2",
+      nextContent: "v3",
       summary: "third",
       source: "manual",
       ownerId: TEST_OWNER,
@@ -154,8 +157,8 @@ describe("RevisionLog.list pagination", () => {
       recs.push(
         await RevisionLog.record({
           docId: doc.id,
-          content: `v${i}`,
           prevContent: `v${i - 1}`,
+          nextContent: `v${i}`,
           summary: `r${i}`,
           source: "manual",
           ownerId: TEST_OWNER,
@@ -199,8 +202,8 @@ describe("RevisionLog retention", () => {
       all.push(
         await RevisionLog.record({
           docId: doc.id,
-          content: `v${i}`,
           prevContent: `v${i - 1}`,
+          nextContent: `v${i}`,
           summary: `r${i}`,
           source: "manual",
           ownerId: TEST_OWNER,
@@ -230,8 +233,8 @@ describe("RevisionLog.get", () => {
     const docB = await createTestDoc("doc B");
     const recA = await RevisionLog.record({
       docId: docA.id,
-      content: "doc A v2",
       prevContent: docA.content,
+      nextContent: "doc A v2",
       summary: null,
       source: "manual",
       ownerId: TEST_OWNER,

--- a/src/lib/revision-log.test.ts
+++ b/src/lib/revision-log.test.ts
@@ -1,0 +1,242 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, sql } from "@vercel/postgres";
+import { insertDoc, type Doc } from "./db";
+import { generateSlug } from "./slug";
+import { stripMarkdown } from "./strip-md";
+import * as RevisionLog from "./revision-log";
+
+const TEST_OWNER = "__test_revision_log__";
+
+async function createTestDoc(content: string, title = "Test"): Promise<Doc> {
+  return insertDoc({
+    slug: generateSlug(),
+    ownerId: TEST_OWNER,
+    title,
+    content,
+    kind: null,
+    searchText: stripMarkdown(content),
+  });
+}
+
+beforeAll(async () => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error(
+      "POSTGRES_URL not set — RevisionLog integration tests need a real Postgres connection (.env.local).",
+    );
+  }
+});
+
+afterAll(async () => {
+  // Cascade-deletes any doc_revisions belonging to test docs.
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+});
+
+describe("RevisionLog.record + get round-trip", () => {
+  it("persists a revision and returns it via get(docId, externalId)", async () => {
+    const doc = await createTestDoc("# Original\n\nbody");
+    const result = await RevisionLog.record({
+      docId: doc.id,
+      content: "# Updated\n\nbody",
+      prevContent: doc.content,
+      summary: "Title bump",
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+
+    expect(result.externalId).toMatch(/^rv_/);
+    expect(result.createdAt).toBeInstanceOf(Date);
+
+    const fetched = await RevisionLog.get(doc.id, result.externalId);
+    expect(fetched).not.toBeNull();
+    expect(fetched).toMatchObject({
+      externalId: result.externalId,
+      docId: doc.id,
+      content: "# Updated\n\nbody",
+      summary: "Title bump",
+      source: "manual",
+      createdBy: TEST_OWNER,
+    });
+  });
+});
+
+describe("RevisionLog transactional client", () => {
+  it("uses the provided client so record participates in the caller's transaction", async () => {
+    const doc = await createTestDoc("v0");
+    const client = await db.connect();
+    try {
+      await client.query("BEGIN");
+      await RevisionLog.record(
+        {
+          docId: doc.id,
+          content: "v1",
+          prevContent: "v0",
+          summary: "rolled back",
+          source: "manual",
+          ownerId: TEST_OWNER,
+        },
+        client,
+      );
+      await client.query("ROLLBACK");
+    } finally {
+      client.release();
+    }
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(0);
+  });
+});
+
+describe("RevisionLog byte counts", () => {
+  it("records bytesAdded and bytesRemoved computed from the prev→next diff", async () => {
+    const doc = await createTestDoc("hello world");
+    await RevisionLog.record({
+      docId: doc.id,
+      content: "hello universe",
+      prevContent: "hello world",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    const listed = await RevisionLog.list(doc.id);
+    const rev = listed.revisions[0];
+    expect(rev).toBeDefined();
+    expect(rev!.bytesAdded).toBeGreaterThan(0);
+    expect(rev!.bytesRemoved).toBeGreaterThan(0);
+    // "world" (5 bytes) → "universe" (8 bytes); both sides nonzero, neither
+    // exceeds the larger of the two strings' lengths.
+    expect(rev!.bytesAdded).toBeLessThanOrEqual(8);
+    expect(rev!.bytesRemoved).toBeLessThanOrEqual(5);
+  });
+});
+
+describe("RevisionLog.list", () => {
+  it("returns revisions newest-first for the given doc", async () => {
+    const doc = await createTestDoc("v0");
+    const r1 = await RevisionLog.record({
+      docId: doc.id,
+      content: "v1",
+      prevContent: "v0",
+      summary: "first",
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    const r2 = await RevisionLog.record({
+      docId: doc.id,
+      content: "v2",
+      prevContent: "v1",
+      summary: "second",
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    const r3 = await RevisionLog.record({
+      docId: doc.id,
+      content: "v3",
+      prevContent: "v2",
+      summary: "third",
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions.map((r) => r.externalId)).toEqual([
+      r3.externalId,
+      r2.externalId,
+      r1.externalId,
+    ]);
+  });
+});
+
+describe("RevisionLog.list pagination", () => {
+  it("paginates newest-first via cursor", async () => {
+    const doc = await createTestDoc("v0");
+    const recs = [];
+    for (let i = 1; i <= 5; i++) {
+      recs.push(
+        await RevisionLog.record({
+          docId: doc.id,
+          content: `v${i}`,
+          prevContent: `v${i - 1}`,
+          summary: `r${i}`,
+          source: "manual",
+          ownerId: TEST_OWNER,
+        }),
+      );
+    }
+    // Newest-first order is r5, r4, r3, r2, r1.
+    const expected = [...recs].reverse().map((r) => r.externalId);
+
+    const page1 = await RevisionLog.list(doc.id, { limit: 2 });
+    expect(page1.revisions.map((r) => r.externalId)).toEqual(
+      expected.slice(0, 2),
+    );
+    expect(page1.nextCursor).not.toBeNull();
+
+    const page2 = await RevisionLog.list(doc.id, {
+      limit: 2,
+      cursor: page1.nextCursor!,
+    });
+    expect(page2.revisions.map((r) => r.externalId)).toEqual(
+      expected.slice(2, 4),
+    );
+    expect(page2.nextCursor).not.toBeNull();
+
+    const page3 = await RevisionLog.list(doc.id, {
+      limit: 2,
+      cursor: page2.nextCursor!,
+    });
+    expect(page3.revisions.map((r) => r.externalId)).toEqual(
+      expected.slice(4, 5),
+    );
+    expect(page3.nextCursor).toBeNull();
+  });
+});
+
+describe("RevisionLog retention", () => {
+  it("keeps only the most recent 50 revisions per doc", async () => {
+    const doc = await createTestDoc("v0");
+    const all = [];
+    for (let i = 1; i <= 52; i++) {
+      all.push(
+        await RevisionLog.record({
+          docId: doc.id,
+          content: `v${i}`,
+          prevContent: `v${i - 1}`,
+          summary: `r${i}`,
+          source: "manual",
+          ownerId: TEST_OWNER,
+        }),
+      );
+    }
+    const listed = await RevisionLog.list(doc.id, { limit: 100 });
+    expect(listed.revisions).toHaveLength(50);
+    // The two oldest revisions (r1, r2) should have been pruned.
+    const survivingIds = new Set(listed.revisions.map((r) => r.externalId));
+    expect(survivingIds.has(all[0]!.externalId)).toBe(false);
+    expect(survivingIds.has(all[1]!.externalId)).toBe(false);
+    // The newest should still be present.
+    expect(survivingIds.has(all[51]!.externalId)).toBe(true);
+  }, 15_000);
+});
+
+describe("RevisionLog.get", () => {
+  it("returns null when no revision exists for the given externalId", async () => {
+    const doc = await createTestDoc("body");
+    const fetched = await RevisionLog.get(doc.id, "rv_doesnotexist");
+    expect(fetched).toBeNull();
+  });
+
+  it("does not return revisions from other docs (docId-scoped)", async () => {
+    const docA = await createTestDoc("doc A");
+    const docB = await createTestDoc("doc B");
+    const recA = await RevisionLog.record({
+      docId: docA.id,
+      content: "doc A v2",
+      prevContent: docA.content,
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    const fetched = await RevisionLog.get(docB.id, recA.externalId);
+    expect(fetched).toBeNull();
+  });
+});

--- a/src/lib/revision-log.test.ts
+++ b/src/lib/revision-log.test.ts
@@ -221,6 +221,51 @@ describe("RevisionLog retention", () => {
   }, 15_000);
 });
 
+describe("RevisionLog.countByDoc", () => {
+  it("returns counts keyed by docId for docs with revisions", async () => {
+    const docA = await createTestDoc("v0");
+    const docB = await createTestDoc("v0");
+    await RevisionLog.record({
+      docId: docA.id,
+      prevContent: "v0",
+      nextContent: "v1",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    await RevisionLog.record({
+      docId: docA.id,
+      prevContent: "v1",
+      nextContent: "v2",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    await RevisionLog.record({
+      docId: docB.id,
+      prevContent: "v0",
+      nextContent: "v1",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+    });
+    const counts = await RevisionLog.countByDoc([docA.id, docB.id]);
+    expect(counts[docA.id]).toBe(2);
+    expect(counts[docB.id]).toBe(1);
+  });
+
+  it("omits docs that have no revisions", async () => {
+    const doc = await createTestDoc("only");
+    const counts = await RevisionLog.countByDoc([doc.id]);
+    expect(counts[doc.id]).toBeUndefined();
+  });
+
+  it("returns an empty record for an empty input array", async () => {
+    const counts = await RevisionLog.countByDoc([]);
+    expect(counts).toEqual({});
+  });
+});
+
 describe("RevisionLog.get", () => {
   it("returns null when no revision exists for the given externalId", async () => {
     const doc = await createTestDoc("body");

--- a/src/lib/revision-log.ts
+++ b/src/lib/revision-log.ts
@@ -26,8 +26,10 @@ export type Revision = {
 
 export type RecordInput = {
   docId: string;
-  content: string;
+  /** The state being saved — what restoring this revision would return to. */
   prevContent: string;
+  /** The state about to replace prevContent. Used only to compute byte deltas. */
+  nextContent: string;
   summary: string | null;
   source: RevisionSource;
   ownerId: string;
@@ -45,7 +47,7 @@ export async function record(
   const externalId = `rv_${generateId()}`;
   const { bytesAdded, bytesRemoved } = computeDiff(
     input.prevContent,
-    input.content,
+    input.nextContent,
   );
   const result = await runner.query<{
     external_id: string;
@@ -59,7 +61,7 @@ export async function record(
     [
       externalId,
       input.docId,
-      input.content,
+      input.prevContent,
       input.summary,
       input.source,
       input.ownerId,

--- a/src/lib/revision-log.ts
+++ b/src/lib/revision-log.ts
@@ -1,0 +1,207 @@
+import { sql, type VercelPoolClient } from "@vercel/postgres";
+import { customAlphabet } from "nanoid";
+import { computeDiff } from "./diff-stats";
+
+type Runner = Pick<VercelPoolClient, "query"> | typeof sql;
+
+const ID_ALPHABET =
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const generateId = customAlphabet(ID_ALPHABET, 8);
+
+const RETENTION_KEEP = 50;
+
+export type RevisionSource = "manual" | "cli" | "agent" | "restore";
+
+export type Revision = {
+  externalId: string;
+  docId: string;
+  content: string;
+  summary: string | null;
+  source: RevisionSource;
+  createdBy: string;
+  bytesAdded: number;
+  bytesRemoved: number;
+  createdAt: Date;
+};
+
+export type RecordInput = {
+  docId: string;
+  content: string;
+  prevContent: string;
+  summary: string | null;
+  source: RevisionSource;
+  ownerId: string;
+};
+
+export type RecordResult = {
+  externalId: string;
+  createdAt: Date;
+};
+
+export async function record(
+  input: RecordInput,
+  runner: Runner = sql,
+): Promise<RecordResult> {
+  const externalId = `rv_${generateId()}`;
+  const { bytesAdded, bytesRemoved } = computeDiff(
+    input.prevContent,
+    input.content,
+  );
+  const result = await runner.query<{
+    external_id: string;
+    created_at: Date;
+  }>(
+    `INSERT INTO doc_revisions
+       (external_id, doc_id, content, summary, source, created_by,
+        bytes_added, bytes_removed)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING external_id, created_at`,
+    [
+      externalId,
+      input.docId,
+      input.content,
+      input.summary,
+      input.source,
+      input.ownerId,
+      bytesAdded,
+      bytesRemoved,
+    ],
+  );
+  const row = result.rows[0];
+  if (!row) throw new Error("doc_revisions INSERT returned no rows");
+
+  await runner.query(
+    `DELETE FROM doc_revisions
+     WHERE doc_id = $1
+       AND id NOT IN (
+         SELECT id FROM doc_revisions
+         WHERE doc_id = $1
+         ORDER BY created_at DESC, id DESC
+         LIMIT $2
+       )`,
+    [input.docId, RETENTION_KEEP],
+  );
+
+  return { externalId: row.external_id, createdAt: row.created_at };
+}
+
+type RevisionRow = {
+  external_id: string;
+  doc_id: string;
+  content: string;
+  summary: string | null;
+  source: RevisionSource;
+  created_by: string;
+  bytes_added: number;
+  bytes_removed: number;
+  created_at: Date;
+};
+
+export type RevisionMeta = Omit<Revision, "content">;
+
+export type ListArgs = {
+  limit?: number;
+  cursor?: string;
+};
+
+export type ListResult = {
+  revisions: RevisionMeta[];
+  nextCursor: string | null;
+};
+
+type Cursor = { createdAt: Date; id: string };
+
+function encodeCursor(row: { created_at: Date; id: string }): string {
+  return Buffer.from(`${row.created_at.toISOString()}|${row.id}`).toString(
+    "base64url",
+  );
+}
+
+function decodeCursor(cursor: string): Cursor | null {
+  try {
+    const decoded = Buffer.from(cursor, "base64url").toString("utf8");
+    const sep = decoded.indexOf("|");
+    if (sep <= 0) return null;
+    const ts = decoded.slice(0, sep);
+    const id = decoded.slice(sep + 1);
+    if (!id) return null;
+    const date = new Date(ts);
+    if (isNaN(date.getTime())) return null;
+    return { createdAt: date, id };
+  } catch {
+    return null;
+  }
+}
+
+type ListRow = Omit<RevisionRow, "content"> & { id: string };
+
+export async function list(
+  docId: string,
+  args: ListArgs = {},
+): Promise<ListResult> {
+  const limit = Math.max(1, Math.min(100, args.limit ?? 20));
+  const cursor = args.cursor ? decodeCursor(args.cursor) : null;
+  const fetchLimit = limit + 1;
+
+  const result = cursor
+    ? await sql<ListRow>`
+        SELECT id, external_id, doc_id, summary, source, created_by,
+               bytes_added, bytes_removed, created_at
+        FROM doc_revisions
+        WHERE doc_id = ${docId}
+          AND (created_at, id) < (${cursor.createdAt.toISOString()}, ${cursor.id})
+        ORDER BY created_at DESC, id DESC
+        LIMIT ${fetchLimit}
+      `
+    : await sql<ListRow>`
+        SELECT id, external_id, doc_id, summary, source, created_by,
+               bytes_added, bytes_removed, created_at
+        FROM doc_revisions
+        WHERE doc_id = ${docId}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ${fetchLimit}
+      `;
+
+  const rows = result.rows;
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const last = page[page.length - 1];
+  const nextCursor = hasMore && last ? encodeCursor(last) : null;
+  const revisions = page.map((row) => ({
+    externalId: row.external_id,
+    docId: row.doc_id,
+    summary: row.summary,
+    source: row.source,
+    createdBy: row.created_by,
+    bytesAdded: row.bytes_added,
+    bytesRemoved: row.bytes_removed,
+    createdAt: row.created_at,
+  }));
+  return { revisions, nextCursor };
+}
+
+export async function get(
+  docId: string,
+  externalId: string,
+): Promise<Revision | null> {
+  const result = await sql<RevisionRow>`
+    SELECT external_id, doc_id, content, summary, source, created_by,
+           bytes_added, bytes_removed, created_at
+    FROM doc_revisions
+    WHERE doc_id = ${docId} AND external_id = ${externalId}
+    LIMIT 1
+  `;
+  const row = result.rows[0];
+  if (!row) return null;
+  return {
+    externalId: row.external_id,
+    docId: row.doc_id,
+    content: row.content,
+    summary: row.summary,
+    source: row.source,
+    createdBy: row.created_by,
+    bytesAdded: row.bytes_added,
+    bytesRemoved: row.bytes_removed,
+    createdAt: row.created_at,
+  };
+}

--- a/src/lib/revision-log.ts
+++ b/src/lib/revision-log.ts
@@ -182,6 +182,24 @@ export async function list(
   return { revisions, nextCursor };
 }
 
+export async function countByDoc(
+  docIds: string[],
+): Promise<Record<string, number>> {
+  if (docIds.length === 0) return {};
+  const result = await sql.query<{ doc_id: string; count: string }>(
+    `SELECT doc_id, COUNT(*)::text AS count
+     FROM doc_revisions
+     WHERE doc_id = ANY($1::uuid[])
+     GROUP BY doc_id`,
+    [docIds],
+  );
+  const counts: Record<string, number> = {};
+  for (const row of result.rows) {
+    counts[row.doc_id] = parseInt(row.count, 10);
+  }
+  return counts;
+}
+
 export async function get(
   docId: string,
   externalId: string,

--- a/src/lib/route-helpers.test.ts
+++ b/src/lib/route-helpers.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "./api-tokens";
+import { insertDoc, type Doc } from "./db";
+import { generateSlug } from "./slug";
+import { stripMarkdown } from "./strip-md";
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { requireOwnedDoc } from "./route-helpers";
+
+const TEST_OWNER = "__test_route_helpers__";
+const OTHER_OWNER = "__test_route_helpers_other__";
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set — route-helpers tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${OTHER_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${OTHER_OWNER}`;
+});
+
+async function setup(ownerId: string): Promise<{ token: string; doc: Doc }> {
+  const t = await createApiToken(ownerId, "test");
+  const doc = await insertDoc({
+    slug: generateSlug(),
+    ownerId,
+    title: "T",
+    content: "body",
+    kind: null,
+    searchText: stripMarkdown("body"),
+  });
+  return { token: t.plaintext, doc };
+}
+
+function makeReq(token: string | null): Request {
+  const headers = new Headers();
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return new Request("http://localhost/", { headers });
+}
+
+describe("requireOwnedDoc failure modes", () => {
+  it("returns a 401 response when no auth is provided", async () => {
+    const { doc } = await setup(TEST_OWNER);
+    const result = await requireOwnedDoc(makeReq(null), doc.slug);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  it("returns a 404 response when the slug doesn't exist", async () => {
+    const { token } = await setup(TEST_OWNER);
+    const result = await requireOwnedDoc(makeReq(token), "no-such-slug");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(404);
+    }
+  });
+
+  it("returns a 404 response when the doc exists but the auth's owner doesn't match (no existence leak)", async () => {
+    const { doc } = await setup(TEST_OWNER);
+    const other = await setup(OTHER_OWNER);
+    const result = await requireOwnedDoc(makeReq(other.token), doc.slug);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(404);
+    }
+  });
+});
+
+describe("requireOwnedDoc", () => {
+  it("returns the auth and doc on the happy path (bearer-authed owner)", async () => {
+    const { token, doc } = await setup(TEST_OWNER);
+    const result = await requireOwnedDoc(makeReq(token), doc.slug);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.auth.ownerId).toBe(TEST_OWNER);
+      expect(result.auth.via).toBe("bearer");
+      expect(result.doc.id).toBe(doc.id);
+      expect(result.doc.slug).toBe(doc.slug);
+    }
+  });
+});

--- a/src/lib/route-helpers.ts
+++ b/src/lib/route-helpers.ts
@@ -1,0 +1,30 @@
+import { requireAuth, type AuthResult } from "@/lib/auth";
+import { getDocBySlug, type Doc } from "@/lib/db";
+
+export type AuthSuccess = Extract<AuthResult, { authenticated: true }>;
+
+export type OwnedDocResult =
+  | { ok: true; auth: AuthSuccess; doc: Doc }
+  | { ok: false; response: Response };
+
+export function jsonError(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export async function requireOwnedDoc(
+  req: Request,
+  slug: string,
+): Promise<OwnedDocResult> {
+  const auth = await requireAuth(req);
+  if (!auth.authenticated) {
+    return { ok: false, response: jsonError(auth.status, auth.reason) };
+  }
+  const doc = await getDocBySlug(slug);
+  if (!doc || doc.ownerId !== auth.ownerId) {
+    return { ok: false, response: jsonError(404, "Document not found") };
+  }
+  return { ok: true, auth, doc };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
     globals: false,
     setupFiles: ["./vitest.setup.ts"],
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     globals: false,
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,4 @@
+import { config } from "dotenv";
+import path from "node:path";
+
+config({ path: path.resolve(__dirname, ".env.local") });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,5 @@
 import { config } from "dotenv";
 import path from "node:path";
+import "@testing-library/jest-dom/vitest";
 
 config({ path: path.resolve(__dirname, ".env.local") });


### PR DESCRIPTION
Closes #45.

## Summary

Adds full document revision history with a restore flow. Every content mutation through any path (dashboard PATCH, future agent edits, restore itself) now snapshots the prior state to a new \`doc_revisions\` table. Operators can browse history per-doc, view any prior content, and restore — with a two-click inline confirm.

## Architecture

Full design in [\`docs/architecture/revision-history.md\`](../blob/feat/doc-revision-history/docs/architecture/revision-history.md). Headlines:

- **\`DocMutationPath\` is the single chokepoint.** Every content write — past, present, future — flows through one function that updates the \`docs\` row and records the prior state to \`RevisionLog\` in one transaction. There is no second code path that touches \`docs.content\`. The existing PATCH handler refactors to call it.
- **Model B snapshots: revisions store the prior content,** not the new content. This means initial-state recoverability is automatic — the first edit captures \`v0\`. No bootstrap snapshot at create time.
- **\`RevisionLog\` stays scoped to one table.** It does not know about \`docs\`. Restore is caller-orchestrated: \`get(externalId)\` then \`DocMutationPath.writeDocContent(..., source: 'restore')\`. The new revision recording the restored state happens automatically.
- **Source enum reflects endpoint context, not auth method:** \`'manual' | 'cli' | 'agent' | 'restore'\`. The \`'agent'\` value is reserved for #46 so that ticket needs no enum migration.
- **History UI lives at authed \`/edit/<slug>/revisions\` and \`/edit/<slug>/revisions/<id>\`** — never extends the public \`/v/<slug>\` reader, so history can't leak via guessable URLs.
- **Retention: last 50 per doc, prune on insert.**

## What's in the PR

**Backend (TDD'd, integration tests against real Postgres):**
- Migration \`007_create_doc_revisions_table.sql\` — table + \`doc_revision_source\` enum
- \`DiffStats\` (\`src/lib/diff-stats.ts\`) — UTF-8 byte-counted diff
- \`RevisionLog\` (\`src/lib/revision-log.ts\`) — \`record\` / \`list\` / \`get\` / \`countByDoc\` with cursor pagination, retention, transactional client support
- \`DocMutationPath\` (\`src/lib/doc-mutation-path.ts\`) — atomic content-write chokepoint
- \`requireOwnedDoc\` helper (\`src/lib/route-helpers.ts\`) — auth + slug-to-doc + ownership glue, used by 4 route handlers

**API verbs (route-level integration tests):**
- \`GET /api/docs/<slug>/revisions\` — paginated metadata
- \`GET /api/docs/<slug>/revisions/<id>\` — full revision content
- \`POST /api/docs/<slug>/restore\` — two-click confirm wired to this verb
- Refactored \`PATCH /api/docs/<slug>\` content writes route through \`DocMutationPath\`

**UI:**
- \`/edit/<slug>/revisions\` list route — single-line dense rows on desktop, stacked summary-led on mobile
- \`/edit/<slug>/revisions/<id>\` detail route — two-row header (metadata above, summary + restore button below), reuses \`MarkdownRenderer\` + \`FrontmatterDisclosure\`
- \`RestoreButton\` with pure state-machine reducer (TDD'd) and a 2px ochre rule that animates the 3-second countdown via CSS keyframe
- \`HistoryLink\` desktop icon with a tooltip showing the revision count, plus a "History" entry in the mobile row-kebab
- Dashboard date column switched to \`updatedAt\` with a clarifying tooltip

**Test infrastructure additions:**
- \`vitest.setup.ts\` loads \`.env.local\` so DB integration tests have a connection
- \`@testing-library/react\` + \`happy-dom\` for component-level tests; per-file \`@vitest-environment happy-dom\` directive

## Tests

161 tests, all green. Mix of pure unit (\`DiffStats\`, reducers, display helpers), DB integration (\`RevisionLog\`, \`DocMutationPath\`, \`route-helpers\`), HTTP route handler tests (PATCH + 3 history verbs), and component tests (\`RestoreButton\`, \`EditLink\`).

\`pnpm lint\` and \`pnpm tsc --noEmit\` clean. Production \`pnpm build\` clean.

## Notable decisions made during build

- **Post-restore returns to \`/edit/<slug>\`**, not \`/v/<slug>\`. Original brief said the public reader; persona critique flagged it as disorienting (operator was in dashboard chrome, gets dropped on the public surface). Returning to edit keeps them in operator mode.
- **Source enum displayed as user labels** (\`Edit\` / \`API\` / \`Agent\` / \`Restored\`) via \`lib/revision-display.ts\`. The raw enum values are engineering shorthand and were too prominent in the original chrome.
- **The "(no message)" fallback** in muted text replaces summary on rows where it's null, so the second-row layout (summary + restore button) always has both elements.

## Out of scope (deferred follow-ups noted in critique)

- Region tags on revision rows (e.g. "frontmatter changed" vs "body changed") — would help answer "what changed" without a diff view. Cheap follow-up; mentioned in the discussion above.
- Inline diff view between revisions or against current state.
- Keyboard nav between revision rows.
- Filter / search within the revisions list (relevant once \`'agent'\` rows arrive in #46).
- DELETE undo (soft-delete) — explicitly out of scope per the architecture doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added document revision history system allowing users to view, list, and restore previous versions of documents
  * Implemented restore confirmation UI with 3-second countdown timer
  * Added revision detail pages displaying historical snapshots with metadata (timestamps, byte changes)

* **Documentation**
  * Added architecture documentation for revision-history and AI-first API systems

* **Tests**
  * Comprehensive test coverage for revision endpoints and UI components

* **Chores**
  * Updated database schema to support revision tracking
  * Added dependencies for diff calculation and testing utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->