### PR TITLE
feat: AI-first API — agent ops, fetch, create routes (#46)

### DIFF
--- a/src/app/api/agent/docs/[slug]/edits/route.test.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.test.ts
@@ -205,12 +205,17 @@ describe("POST /api/agent/docs/[slug]/edits — structured 409 errors", () => {
       error: string;
       failedAt: number;
       matchCount: number;
-      previewLines: { line: number; text: string }[];
+      matches: {
+        line: number;
+        column: number;
+        previewLines: { line: number; text: string }[];
+      }[];
     };
     expect(body.error).toBe("ambiguous_match");
     expect(body.failedAt).toBe(0);
     expect(body.matchCount).toBe(2);
-    expect(body.previewLines.length).toBeGreaterThan(0);
+    expect(body.matches).toHaveLength(2);
+    expect(body.matches[0]?.previewLines.length).toBeGreaterThan(0);
 
     const listed = await RevisionLog.list(doc.id);
     expect(listed.revisions).toHaveLength(0);

--- a/src/app/api/agent/docs/[slug]/edits/route.test.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.test.ts
@@ -1,0 +1,261 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "@/lib/api-tokens";
+import { insertDoc } from "@/lib/db";
+import { generateSlug } from "@/lib/slug";
+import { stripMarkdown } from "@/lib/strip-md";
+import * as RevisionLog from "@/lib/revision-log";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { POST } from "./route";
+
+const TEST_OWNER = "__test_agent_edits__";
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set — route tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+});
+
+async function setupAuthorizedDoc(content: string) {
+  const token = await createApiToken(TEST_OWNER, "test");
+  const doc = await insertDoc({
+    slug: generateSlug(),
+    ownerId: TEST_OWNER,
+    title: "Test",
+    content,
+    kind: null,
+    searchText: stripMarkdown(content),
+  });
+  return { token, doc };
+}
+
+function postReq(slug: string, body: unknown, token: string | null) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token) headers.authorization = `Bearer ${token}`;
+  const req = new NextRequest(
+    `http://localhost/api/agent/docs/${slug}/edits`,
+    { method: "POST", headers, body: JSON.stringify(body) },
+  );
+  return POST(req, { params: Promise.resolve({ slug }) });
+}
+
+describe("POST /api/agent/docs/[slug]/edits — happy path", () => {
+  it("applies a replace op, updates content, and records an agent revision", async () => {
+    const { token, doc } = await setupAuthorizedDoc("hello foo world\n");
+    const res = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      doc: { content: string; slug: string };
+      revisionId: string;
+    };
+    expect(body.doc.content).toBe("hello bar world\n");
+    expect(body.doc.slug).toBe(doc.slug);
+    expect(body.revisionId).toMatch(/^rv_/);
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(1);
+    expect(listed.revisions[0]?.source).toBe("agent");
+  });
+
+  it("applies a batch of ops atomically", async () => {
+    const { token, doc } = await setupAuthorizedDoc(
+      "one\ntwo\nthree\nfour\n",
+    );
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [
+          { type: "deleteLineRange", from: 2, to: 2 },
+          { type: "insertAfterLine", line: 4, content: "five" },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { doc: { content: string } };
+    expect(body.doc.content).toBe("one\nthree\nfour\nfive\n");
+  });
+
+  it("does NOT record a revision when applied ops produce content identical to the input", async () => {
+    // This shouldn't happen in practice, but the route must preserve the same
+    // no-op invariant the existing PATCH route enforces (see #45 review fix).
+    const { token, doc } = await setupAuthorizedDoc("foo bar\n");
+    const res = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "foo", replace: "foo" }] },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(0);
+  });
+});
+
+describe("POST /api/agent/docs/[slug]/edits — auth and shape errors", () => {
+  it("returns 401 when no auth is provided", async () => {
+    const { doc } = await setupAuthorizedDoc("x\n");
+    const res = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "x", replace: "y" }] },
+      null,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the slug does not belong to the caller", async () => {
+    const { token } = await setupAuthorizedDoc("x\n");
+    // Make a doc owned by a different owner_id
+    const otherSlug = generateSlug();
+    await insertDoc({
+      slug: otherSlug,
+      ownerId: "__other_owner__",
+      title: "Other",
+      content: "z\n",
+      kind: null,
+      searchText: "z",
+    });
+    try {
+      const res = await postReq(
+        otherSlug,
+        { ops: [{ type: "replace", find: "z", replace: "y" }] },
+        token.plaintext,
+      );
+      expect(res.status).toBe(404);
+    } finally {
+      await sql`DELETE FROM docs WHERE owner_id = '__other_owner__'`;
+    }
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const { token, doc } = await setupAuthorizedDoc("x\n");
+    const req = new NextRequest(
+      `http://localhost/api/agent/docs/${doc.slug}/edits`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token.plaintext}`,
+        },
+        body: "{not json",
+      },
+    );
+    const res = await POST(req, { params: Promise.resolve({ slug: doc.slug }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when ops is missing", async () => {
+    const { token, doc } = await setupAuthorizedDoc("x\n");
+    const res = await postReq(doc.slug, {}, token.plaintext);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when ops is an empty array", async () => {
+    const { token, doc } = await setupAuthorizedDoc("x\n");
+    const res = await postReq(doc.slug, { ops: [] }, token.plaintext);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 with op-index info when an op is malformed", async () => {
+    const { token, doc } = await setupAuthorizedDoc("x\n");
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [
+          { type: "replace", find: "x", replace: "y" },
+          { type: "deleteLineRange", from: 5, to: 1 },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/ops\[1\]|index 1/i);
+  });
+});
+
+describe("POST /api/agent/docs/[slug]/edits — structured 409 errors", () => {
+  it("returns 409 with matchCount and previewLines when a query is ambiguous", async () => {
+    const content = "foo line one\nfoo line two\n";
+    const { token, doc } = await setupAuthorizedDoc(content);
+    const res = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+      token.plaintext,
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      error: string;
+      failedAt: number;
+      matchCount: number;
+      previewLines: { line: number; text: string }[];
+    };
+    expect(body.error).toBe("ambiguous_match");
+    expect(body.failedAt).toBe(0);
+    expect(body.matchCount).toBe(2);
+    expect(body.previewLines.length).toBeGreaterThan(0);
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(0);
+  });
+
+  it("returns 409 with no_match when query is not found", async () => {
+    const { token, doc } = await setupAuthorizedDoc("hello\n");
+    const res = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "missing", replace: "x" }] },
+      token.plaintext,
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; failedAt: number };
+    expect(body.error).toBe("no_match");
+    expect(body.failedAt).toBe(0);
+  });
+
+  it("returns 409 with line_out_of_range for invalid line numbers", async () => {
+    const { token, doc } = await setupAuthorizedDoc("only one line\n");
+    const res = await postReq(
+      doc.slug,
+      { ops: [{ type: "insertAfterLine", line: 99, content: "x" }] },
+      token.plaintext,
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; failedAt: number };
+    expect(body.error).toBe("line_out_of_range");
+    expect(body.failedAt).toBe(0);
+  });
+});
+
+describe("POST /api/agent/docs/[slug]/edits — content size limit", () => {
+  it("rejects ops that would push content past 1 MB", async () => {
+    const { token, doc } = await setupAuthorizedDoc("seed\n");
+    const huge = "x".repeat(1024 * 1024 + 10);
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [
+          { type: "replace", find: "seed", replace: huge },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(413);
+  });
+});

--- a/src/app/api/agent/docs/[slug]/edits/route.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.ts
@@ -56,6 +56,15 @@ export async function POST(
 ) {
   const { slug } = await context.params;
 
+  // Reject oversized requests before buffering. The 1 MB cap on the resulting
+  // doc is enforced after applying ops, but a malicious caller could still
+  // send a huge ops payload (e.g. a giant `replace.replace`) that would OOM
+  // the server during req.json(). Mirror the PATCH route's content-length guard.
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && parseInt(contentLength, 10) > MAX_BYTES) {
+    return jsonError(413, "Request body exceeds 1MB limit");
+  }
+
   let body: Body;
   try {
     body = (await req.json()) as Body;

--- a/src/app/api/agent/docs/[slug]/edits/route.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { writeDocContent } from "@/lib/doc-mutation-path";
+import { resolveTitle } from "@/lib/title";
+import { stripMarkdown } from "@/lib/strip-md";
+import { jsonError, requireOwnedDoc } from "@/lib/route-helpers";
+import { parseEditOps } from "@/lib/edit-op-schema";
+import { apply, type ApplierError } from "@/lib/operation-applier";
+
+const MAX_BYTES = 1024 * 1024;
+
+type Body = { ops?: unknown; summary?: unknown };
+
+function applierErrorBody(
+  error: ApplierError,
+  failedAt: number,
+): Record<string, unknown> {
+  switch (error.kind) {
+    case "no_match":
+      return { error: "no_match", failedAt, query: error.query };
+    case "ambiguous_match":
+      return {
+        error: "ambiguous_match",
+        failedAt,
+        query: error.query,
+        matchCount: error.matchCount,
+        previewLines: error.previewLines,
+      };
+    case "line_out_of_range":
+      return {
+        error: "line_out_of_range",
+        failedAt,
+        line: error.line,
+        documentLines: error.documentLines,
+      };
+    case "range_out_of_range":
+      return {
+        error: "range_out_of_range",
+        failedAt,
+        from: error.from,
+        to: error.to,
+        documentLines: error.documentLines,
+      };
+    case "overlapping_line_ops":
+      return {
+        error: "overlapping_line_ops",
+        failedAt,
+        conflictsWith: error.conflictsWith,
+      };
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await context.params;
+
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return jsonError(400, "Invalid JSON body");
+  }
+  if (typeof body !== "object" || body === null) {
+    return jsonError(400, "JSON body required");
+  }
+
+  const parsed = parseEditOps(body.ops);
+  if (!parsed.ok) {
+    return jsonError(400, parsed.error);
+  }
+
+  let summary: string | null = null;
+  if (body.summary !== undefined) {
+    if (body.summary !== null && typeof body.summary !== "string") {
+      return jsonError(400, "summary must be a string or null");
+    }
+    summary = body.summary;
+  }
+
+  const owned = await requireOwnedDoc(req, slug);
+  if (!owned.ok) return owned.response;
+  const { auth, doc } = owned;
+
+  const result = apply(doc.content, parsed.ops);
+  if (!result.ok) {
+    return new Response(JSON.stringify(applierErrorBody(result.error, result.failedAt)), {
+      status: 409,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  if (Buffer.byteLength(result.content, "utf8") > MAX_BYTES) {
+    return jsonError(413, "Content exceeds 1MB limit");
+  }
+
+  // No-op short-circuit: skip the chokepoint write so a no-op batch doesn't
+  // burn a retention slot. Mirrors the PATCH route's same-content guard.
+  if (result.content === doc.content) {
+    return new Response(
+      JSON.stringify({
+        doc: {
+          id: doc.id,
+          slug: doc.slug,
+          title: doc.title,
+          kind: doc.kind,
+          content: doc.content,
+          createdAt: doc.createdAt,
+          updatedAt: doc.updatedAt,
+        },
+        revisionId: null,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  const writeResult = await writeDocContent({
+    docId: doc.id,
+    newContent: result.content,
+    newTitle: resolveTitle(result.content, doc.title),
+    newSearchText: stripMarkdown(result.content),
+    summary,
+    source: "agent",
+    ownerId: auth.ownerId,
+  });
+
+  revalidatePath("/");
+  revalidatePath(`/v/${slug}`);
+
+  return new Response(
+    JSON.stringify({
+      doc: {
+        id: writeResult.doc.id,
+        slug: writeResult.doc.slug,
+        title: writeResult.doc.title,
+        kind: writeResult.doc.kind,
+        content: writeResult.doc.content,
+        createdAt: writeResult.doc.createdAt,
+        updatedAt: writeResult.doc.updatedAt,
+      },
+      revisionId: writeResult.revisionId,
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}

--- a/src/app/api/agent/docs/[slug]/edits/route.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.ts
@@ -24,7 +24,7 @@ function applierErrorBody(
         failedAt,
         query: error.query,
         matchCount: error.matchCount,
-        previewLines: error.previewLines,
+        matches: error.matches,
       };
     case "line_out_of_range":
       return {

--- a/src/app/api/agent/docs/[slug]/route.test.ts
+++ b/src/app/api/agent/docs/[slug]/route.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "@/lib/api-tokens";
+import { insertDoc } from "@/lib/db";
+import { generateSlug } from "@/lib/slug";
+import { stripMarkdown } from "@/lib/strip-md";
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { GET } from "./route";
+
+const TEST_OWNER = "__test_agent_get_doc__";
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set — route tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+});
+
+async function setupAuthorizedDoc(content: string, title = "Test") {
+  const token = await createApiToken(TEST_OWNER, "test");
+  const doc = await insertDoc({
+    slug: generateSlug(),
+    ownerId: TEST_OWNER,
+    title,
+    content,
+    kind: null,
+    searchText: stripMarkdown(content),
+  });
+  return { token, doc };
+}
+
+function getReq(slug: string, token: string | null) {
+  const headers: Record<string, string> = {};
+  if (token) headers.authorization = `Bearer ${token}`;
+  const req = new NextRequest(`http://localhost/api/agent/docs/${slug}`, {
+    method: "GET",
+    headers,
+  });
+  return GET(req, { params: Promise.resolve({ slug }) });
+}
+
+describe("GET /api/agent/docs/[slug]", () => {
+  it("returns 200 with content and updatedAt for an owned doc", async () => {
+    const { token, doc } = await setupAuthorizedDoc("# Hello\n\nbody\n", "Hi");
+    const res = await getReq(doc.slug, token.plaintext);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      slug: string;
+      title: string;
+      kind: string | null;
+      content: string;
+      updatedAt: string;
+    };
+    expect(body.slug).toBe(doc.slug);
+    expect(body.title).toBe("Hi");
+    expect(body.content).toBe("# Hello\n\nbody\n");
+    expect(typeof body.updatedAt).toBe("string");
+    expect(new Date(body.updatedAt).getTime()).toBeGreaterThan(0);
+  });
+
+  it("returns 401 without auth", async () => {
+    const { doc } = await setupAuthorizedDoc("x\n");
+    const res = await getReq(doc.slug, null);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for a slug not owned by the caller", async () => {
+    const { token } = await setupAuthorizedDoc("x\n");
+    const otherSlug = generateSlug();
+    await insertDoc({
+      slug: otherSlug,
+      ownerId: "__other_owner_get__",
+      title: "Other",
+      content: "y\n",
+      kind: null,
+      searchText: "y",
+    });
+    try {
+      const res = await getReq(otherSlug, token.plaintext);
+      expect(res.status).toBe(404);
+    } finally {
+      await sql`DELETE FROM docs WHERE owner_id = '__other_owner_get__'`;
+    }
+  });
+});

--- a/src/app/api/agent/docs/[slug]/route.ts
+++ b/src/app/api/agent/docs/[slug]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server";
+import { requireOwnedDoc } from "@/lib/route-helpers";
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await context.params;
+  const owned = await requireOwnedDoc(req, slug);
+  if (!owned.ok) return owned.response;
+  const { doc } = owned;
+
+  return new Response(
+    JSON.stringify({
+      id: doc.id,
+      slug: doc.slug,
+      title: doc.title,
+      kind: doc.kind,
+      content: doc.content,
+      createdAt: doc.createdAt,
+      updatedAt: doc.updatedAt,
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    },
+  );
+}

--- a/src/app/api/agent/docs/route.test.ts
+++ b/src/app/api/agent/docs/route.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "@/lib/api-tokens";
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { POST } from "./route";
+
+const TEST_OWNER = "__test_agent_create_doc__";
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set — route tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+});
+
+function postReq(body: unknown, token: string | null) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token) headers.authorization = `Bearer ${token}`;
+  const req = new NextRequest("http://localhost/api/agent/docs", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return POST(req);
+}
+
+describe("POST /api/agent/docs", () => {
+  it("creates a doc with content, returns 201 + slug + viewUrl", async () => {
+    const token = await createApiToken(TEST_OWNER, "test");
+    const res = await postReq(
+      { content: "# Hello agent\n\nbody\n" },
+      token.plaintext,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      id: string;
+      slug: string;
+      title: string;
+      content: string;
+      viewUrl: string;
+      createdAt: string;
+    };
+    expect(body.slug).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(body.title).toBe("Hello agent");
+    expect(body.content).toBe("# Hello agent\n\nbody\n");
+    expect(body.viewUrl).toContain(`/v/${body.slug}`);
+  });
+
+  it("respects an explicit title in the JSON body", async () => {
+    const token = await createApiToken(TEST_OWNER, "test");
+    const res = await postReq(
+      { content: "# h1 wins by default\nx\n", title: "Override" },
+      token.plaintext,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { title: string };
+    expect(body.title).toBe("Override");
+  });
+
+  it("returns 400 when content is missing", async () => {
+    const token = await createApiToken(TEST_OWNER, "test");
+    const res = await postReq({ title: "no body" }, token.plaintext);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when content is empty", async () => {
+    const token = await createApiToken(TEST_OWNER, "test");
+    const res = await postReq({ content: "   \n" }, token.plaintext);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await postReq({ content: "x\n" }, null);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 413 when content exceeds 1MB", async () => {
+    const token = await createApiToken(TEST_OWNER, "test");
+    const huge = "x".repeat(1024 * 1024 + 10);
+    const res = await postReq({ content: huge }, token.plaintext);
+    expect(res.status).toBe(413);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const token = await createApiToken(TEST_OWNER, "test");
+    const req = new NextRequest("http://localhost/api/agent/docs", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token.plaintext}`,
+      },
+      body: "{not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/agent/docs/route.ts
+++ b/src/app/api/agent/docs/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { generateSlug } from "@/lib/slug";
+import { resolveTitle } from "@/lib/title";
+import { stripMarkdown } from "@/lib/strip-md";
+import { insertDoc } from "@/lib/db";
+import { parseKind } from "@/lib/kind";
+import { jsonError } from "@/lib/route-helpers";
+
+const MAX_BYTES = 1024 * 1024;
+const MAX_SLUG_RETRIES = 5;
+
+type CreateInput = {
+  content?: unknown;
+  title?: unknown;
+  kind?: unknown;
+};
+
+function isUniqueViolation(err: unknown): boolean {
+  return Boolean(
+    err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: string }).code === "23505",
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (!auth.authenticated) {
+    return jsonError(auth.status, auth.reason);
+  }
+
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && parseInt(contentLength, 10) > MAX_BYTES) {
+    return jsonError(413, "Content exceeds 1MB limit");
+  }
+
+  let body: CreateInput;
+  try {
+    body = (await req.json()) as CreateInput;
+  } catch {
+    return jsonError(400, "Invalid JSON body");
+  }
+  if (typeof body !== "object" || body === null) {
+    return jsonError(400, "JSON body required");
+  }
+  if (typeof body.content !== "string") {
+    return jsonError(400, "content must be a string");
+  }
+  if (Buffer.byteLength(body.content, "utf8") > MAX_BYTES) {
+    return jsonError(413, "Content exceeds 1MB limit");
+  }
+  if (!body.content.trim()) {
+    return jsonError(400, "Content is empty");
+  }
+
+  let titleOverride: string | undefined;
+  if (body.title !== undefined) {
+    if (typeof body.title !== "string") {
+      return jsonError(400, "title must be a string");
+    }
+    titleOverride = body.title;
+  }
+
+  const kindResult = parseKind(body.kind);
+  if (!kindResult.ok) {
+    return jsonError(400, kindResult.error);
+  }
+
+  const title = resolveTitle(body.content, titleOverride);
+  const searchText = stripMarkdown(body.content);
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_SLUG_RETRIES; attempt++) {
+    const slug = generateSlug();
+    try {
+      const doc = await insertDoc({
+        slug,
+        ownerId: auth.ownerId,
+        title,
+        content: body.content,
+        kind: kindResult.value,
+        searchText,
+      });
+      const viewUrl = `${req.nextUrl.origin}/v/${doc.slug}`;
+      return new Response(
+        JSON.stringify({
+          id: doc.id,
+          slug: doc.slug,
+          title: doc.title,
+          kind: doc.kind,
+          content: doc.content,
+          viewUrl,
+          createdAt: doc.createdAt,
+          updatedAt: doc.updatedAt,
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    } catch (err) {
+      if (isUniqueViolation(err)) {
+        lastError = err;
+        continue;
+      }
+      console.error("[agent.docs.create] insert failed", err);
+      return jsonError(500, "Failed to save document");
+    }
+  }
+
+  console.error("[agent.docs.create] slug collision retries exhausted", lastError);
+  return jsonError(500, "Could not generate a unique slug");
+}

--- a/src/lib/edit-op-schema.test.ts
+++ b/src/lib/edit-op-schema.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect } from "vitest";
+import { parseEditOp, parseEditOps, type EditOp } from "./edit-op-schema";
+
+describe("parseEditOp — replace", () => {
+  it("accepts a minimal replace op", () => {
+    const result = parseEditOp({
+      type: "replace",
+      find: "foo",
+      replace: "bar",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const op = result.op;
+      expect(op).toEqual({
+        type: "replace",
+        find: "foo",
+        replace: "bar",
+        replaceAll: false,
+      });
+    }
+  });
+
+  it("accepts replace with replaceAll: true", () => {
+    const result = parseEditOp({
+      type: "replace",
+      find: "foo",
+      replace: "bar",
+      replaceAll: true,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok && result.op.type === "replace") {
+      expect(result.op.replaceAll).toBe(true);
+    }
+  });
+
+  it("rejects replace with empty find", () => {
+    const result = parseEditOp({
+      type: "replace",
+      find: "",
+      replace: "bar",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/find/i);
+  });
+
+  it("rejects replace with non-string find", () => {
+    const result = parseEditOp({
+      type: "replace",
+      find: 42,
+      replace: "bar",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/find.*string/i);
+  });
+
+  it("rejects replace with non-string replace", () => {
+    const result = parseEditOp({
+      type: "replace",
+      find: "foo",
+      replace: null,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects replace with non-boolean replaceAll", () => {
+    const result = parseEditOp({
+      type: "replace",
+      find: "foo",
+      replace: "bar",
+      replaceAll: "yes",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/replaceAll/i);
+  });
+});
+
+describe("parseEditOp — insertAfterLine / insertBeforeLine", () => {
+  it("accepts a valid insertAfterLine op", () => {
+    const result = parseEditOp({
+      type: "insertAfterLine",
+      line: 5,
+      content: "new content",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.op).toEqual({
+        type: "insertAfterLine",
+        line: 5,
+        content: "new content",
+      });
+    }
+  });
+
+  it("accepts insertBeforeLine at line 1", () => {
+    const result = parseEditOp({
+      type: "insertBeforeLine",
+      line: 1,
+      content: "first",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts insertAfterLine at line 0 (insert at top)", () => {
+    // Convention: insertAfterLine line=0 means "before line 1".
+    // Allowed so callers don't need a separate insertAtTop op.
+    const result = parseEditOp({
+      type: "insertAfterLine",
+      line: 0,
+      content: "header",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects insertBeforeLine at line 0", () => {
+    const result = parseEditOp({
+      type: "insertBeforeLine",
+      line: 0,
+      content: "x",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/line/i);
+  });
+
+  it("rejects negative line", () => {
+    const result = parseEditOp({
+      type: "insertAfterLine",
+      line: -1,
+      content: "x",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects non-integer line", () => {
+    const result = parseEditOp({
+      type: "insertAfterLine",
+      line: 1.5,
+      content: "x",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/integer/i);
+  });
+
+  it("rejects non-string content", () => {
+    const result = parseEditOp({
+      type: "insertAfterLine",
+      line: 1,
+      content: 42,
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseEditOp — deleteLineRange", () => {
+  it("accepts a valid range", () => {
+    const result = parseEditOp({
+      type: "deleteLineRange",
+      from: 3,
+      to: 7,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.op).toEqual({ type: "deleteLineRange", from: 3, to: 7 });
+    }
+  });
+
+  it("accepts a single-line range (from === to)", () => {
+    const result = parseEditOp({
+      type: "deleteLineRange",
+      from: 5,
+      to: 5,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects from > to", () => {
+    const result = parseEditOp({
+      type: "deleteLineRange",
+      from: 7,
+      to: 3,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/from.*to|range/i);
+  });
+
+  it("rejects from < 1", () => {
+    const result = parseEditOp({
+      type: "deleteLineRange",
+      from: 0,
+      to: 5,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects non-integer to", () => {
+    const result = parseEditOp({
+      type: "deleteLineRange",
+      from: 1,
+      to: 5.5,
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseEditOp — replaceLineRange", () => {
+  it("accepts a valid replaceLineRange", () => {
+    const result = parseEditOp({
+      type: "replaceLineRange",
+      from: 2,
+      to: 4,
+      content: "new\nlines",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.op).toEqual({
+        type: "replaceLineRange",
+        from: 2,
+        to: 4,
+        content: "new\nlines",
+      });
+    }
+  });
+
+  it("accepts empty content (degenerate to deletion)", () => {
+    const result = parseEditOp({
+      type: "replaceLineRange",
+      from: 2,
+      to: 4,
+      content: "",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects from > to", () => {
+    const result = parseEditOp({
+      type: "replaceLineRange",
+      from: 5,
+      to: 2,
+      content: "x",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects missing content", () => {
+    const result = parseEditOp({
+      type: "replaceLineRange",
+      from: 1,
+      to: 2,
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseEditOp — discriminator and shape", () => {
+  it("rejects non-object input", () => {
+    expect(parseEditOp(null).ok).toBe(false);
+    expect(parseEditOp("foo").ok).toBe(false);
+    expect(parseEditOp(42).ok).toBe(false);
+    expect(parseEditOp([]).ok).toBe(false);
+  });
+
+  it("rejects missing type", () => {
+    const result = parseEditOp({ find: "a", replace: "b" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/type/i);
+  });
+
+  it("rejects unknown type", () => {
+    const result = parseEditOp({ type: "moveLines", from: 1, to: 2 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/type|unknown/i);
+  });
+});
+
+describe("parseEditOps (batch)", () => {
+  it("accepts a non-empty array of ops", () => {
+    const result = parseEditOps([
+      { type: "replace", find: "a", replace: "b" },
+      { type: "deleteLineRange", from: 1, to: 1 },
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.ops).toHaveLength(2);
+  });
+
+  it("rejects non-array input", () => {
+    expect(parseEditOps({ type: "replace", find: "a", replace: "b" }).ok).toBe(
+      false,
+    );
+    expect(parseEditOps(null).ok).toBe(false);
+  });
+
+  it("rejects empty array", () => {
+    const result = parseEditOps([]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/empty|at least/i);
+  });
+
+  it("reports the index of a malformed op", () => {
+    const result = parseEditOps([
+      { type: "replace", find: "a", replace: "b" },
+      { type: "deleteLineRange", from: 5, to: 1 }, // invalid range
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/\[1\]|index 1|second/i);
+    }
+  });
+});
+
+describe("EditOp type narrowing", () => {
+  it("compiles when narrowing on the type discriminator", () => {
+    const op: EditOp = {
+      type: "replace",
+      find: "a",
+      replace: "b",
+      replaceAll: false,
+    };
+    if (op.type === "replace") {
+      expect(typeof op.find).toBe("string");
+      expect(typeof op.replaceAll).toBe("boolean");
+    }
+  });
+});

--- a/src/lib/edit-op-schema.ts
+++ b/src/lib/edit-op-schema.ts
@@ -1,0 +1,210 @@
+export type ReplaceOp = {
+  type: "replace";
+  find: string;
+  replace: string;
+  replaceAll: boolean;
+};
+
+export type InsertAfterLineOp = {
+  type: "insertAfterLine";
+  /** 1-indexed. `0` is allowed as a sentinel meaning "insert at top of file". */
+  line: number;
+  content: string;
+};
+
+export type InsertBeforeLineOp = {
+  type: "insertBeforeLine";
+  /** 1-indexed. Must be >= 1. */
+  line: number;
+  content: string;
+};
+
+export type DeleteLineRangeOp = {
+  type: "deleteLineRange";
+  /** 1-indexed inclusive. */
+  from: number;
+  to: number;
+};
+
+export type ReplaceLineRangeOp = {
+  type: "replaceLineRange";
+  /** 1-indexed inclusive. */
+  from: number;
+  to: number;
+  content: string;
+};
+
+export type EditOp =
+  | ReplaceOp
+  | InsertAfterLineOp
+  | InsertBeforeLineOp
+  | DeleteLineRangeOp
+  | ReplaceLineRangeOp;
+
+export type ParseResult<T> =
+  | { ok: true; op: T }
+  | { ok: false; error: string };
+
+export type ParseBatchResult =
+  | { ok: true; ops: EditOp[] }
+  | { ok: false; error: string };
+
+const KNOWN_TYPES = new Set([
+  "replace",
+  "insertAfterLine",
+  "insertBeforeLine",
+  "deleteLineRange",
+  "replaceLineRange",
+]);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isPositiveInteger(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v >= 1;
+}
+
+function isNonNegativeInteger(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v >= 0;
+}
+
+function parseReplace(input: Record<string, unknown>): ParseResult<ReplaceOp> {
+  if (typeof input.find !== "string") {
+    return { ok: false, error: "replace: find must be a string" };
+  }
+  if (input.find.length === 0) {
+    return { ok: false, error: "replace: find must be non-empty" };
+  }
+  if (typeof input.replace !== "string") {
+    return { ok: false, error: "replace: replace must be a string" };
+  }
+  let replaceAll = false;
+  if (input.replaceAll !== undefined) {
+    if (typeof input.replaceAll !== "boolean") {
+      return { ok: false, error: "replace: replaceAll must be a boolean" };
+    }
+    replaceAll = input.replaceAll;
+  }
+  return {
+    ok: true,
+    op: { type: "replace", find: input.find, replace: input.replace, replaceAll },
+  };
+}
+
+function parseInsert(
+  input: Record<string, unknown>,
+  type: "insertAfterLine" | "insertBeforeLine",
+): ParseResult<InsertAfterLineOp | InsertBeforeLineOp> {
+  const lineMin = type === "insertAfterLine" ? 0 : 1;
+  const lineCheck =
+    lineMin === 0 ? isNonNegativeInteger : isPositiveInteger;
+  if (!lineCheck(input.line)) {
+    return {
+      ok: false,
+      error: `${type}: line must be an integer >= ${lineMin}`,
+    };
+  }
+  if (typeof input.content !== "string") {
+    return { ok: false, error: `${type}: content must be a string` };
+  }
+  return {
+    ok: true,
+    op: { type, line: input.line, content: input.content },
+  };
+}
+
+function parseDeleteRange(
+  input: Record<string, unknown>,
+): ParseResult<DeleteLineRangeOp> {
+  if (!isPositiveInteger(input.from)) {
+    return { ok: false, error: "deleteLineRange: from must be an integer >= 1" };
+  }
+  if (!isPositiveInteger(input.to)) {
+    return { ok: false, error: "deleteLineRange: to must be an integer >= 1" };
+  }
+  if (input.from > input.to) {
+    return {
+      ok: false,
+      error: "deleteLineRange: from must be <= to (invalid range)",
+    };
+  }
+  return {
+    ok: true,
+    op: { type: "deleteLineRange", from: input.from, to: input.to },
+  };
+}
+
+function parseReplaceRange(
+  input: Record<string, unknown>,
+): ParseResult<ReplaceLineRangeOp> {
+  if (!isPositiveInteger(input.from)) {
+    return { ok: false, error: "replaceLineRange: from must be an integer >= 1" };
+  }
+  if (!isPositiveInteger(input.to)) {
+    return { ok: false, error: "replaceLineRange: to must be an integer >= 1" };
+  }
+  if (input.from > input.to) {
+    return {
+      ok: false,
+      error: "replaceLineRange: from must be <= to (invalid range)",
+    };
+  }
+  if (typeof input.content !== "string") {
+    return { ok: false, error: "replaceLineRange: content must be a string" };
+  }
+  return {
+    ok: true,
+    op: {
+      type: "replaceLineRange",
+      from: input.from,
+      to: input.to,
+      content: input.content,
+    },
+  };
+}
+
+export function parseEditOp(input: unknown): ParseResult<EditOp> {
+  if (!isPlainObject(input)) {
+    return { ok: false, error: "op must be a plain object" };
+  }
+  const type = input.type;
+  if (typeof type !== "string") {
+    return { ok: false, error: "op.type is required and must be a string" };
+  }
+  if (!KNOWN_TYPES.has(type)) {
+    return { ok: false, error: `unknown op type: ${type}` };
+  }
+
+  switch (type) {
+    case "replace":
+      return parseReplace(input);
+    case "insertAfterLine":
+    case "insertBeforeLine":
+      return parseInsert(input, type);
+    case "deleteLineRange":
+      return parseDeleteRange(input);
+    case "replaceLineRange":
+      return parseReplaceRange(input);
+    default:
+      return { ok: false, error: `unknown op type: ${type}` };
+  }
+}
+
+export function parseEditOps(input: unknown): ParseBatchResult {
+  if (!Array.isArray(input)) {
+    return { ok: false, error: "ops must be an array" };
+  }
+  if (input.length === 0) {
+    return { ok: false, error: "ops must contain at least one operation" };
+  }
+  const ops: EditOp[] = [];
+  for (let i = 0; i < input.length; i++) {
+    const result = parseEditOp(input[i]);
+    if (!result.ok) {
+      return { ok: false, error: `ops[${i}]: ${result.error}` };
+    }
+    ops.push(result.op);
+  }
+  return { ok: true, ops };
+}

--- a/src/lib/match-resolver.test.ts
+++ b/src/lib/match-resolver.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { findMatches, type Match } from "./match-resolver";
+
+describe("findMatches — basic cases", () => {
+  it("returns an empty array when the query is not found", () => {
+    const matches = findMatches("hello world\n", "xyz");
+    expect(matches).toEqual([]);
+  });
+
+  it("returns a single match with line and column (1-indexed)", () => {
+    const content = "line one\nline two\nline three\n";
+    const matches = findMatches(content, "two");
+    expect(matches).toHaveLength(1);
+    const m = matches[0]!;
+    expect(m.line).toBe(2);
+    expect(m.column).toBe(6); // "line " is 5 chars, "t" at column 6
+    expect(m.start).toBe(content.indexOf("two"));
+    expect(m.end).toBe(m.start + "two".length);
+  });
+
+  it("returns multiple matches in document order", () => {
+    const content = "foo bar\nbaz foo\nfoo end\n";
+    const matches = findMatches(content, "foo");
+    expect(matches).toHaveLength(3);
+    expect(matches.map((m) => m.line)).toEqual([1, 2, 3]);
+    // First column of "foo" on each line
+    expect(matches.map((m) => m.column)).toEqual([1, 5, 1]);
+  });
+
+  it("treats query as a literal string (no regex semantics)", () => {
+    const content = "a.b.c\na+b+c\n";
+    const matches = findMatches(content, "a.b");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.line).toBe(1);
+  });
+});
+
+describe("findMatches — multi-line query", () => {
+  it("finds a query that spans multiple lines", () => {
+    const content = "alpha\nbeta\ngamma\n";
+    const matches = findMatches(content, "alpha\nbeta");
+    expect(matches).toHaveLength(1);
+    const m = matches[0]!;
+    expect(m.line).toBe(1);
+    expect(m.column).toBe(1);
+  });
+
+  it("counts line/column at the START of the match", () => {
+    const content = "x\nfoo\nbar\nend\n";
+    const matches = findMatches(content, "foo\nbar");
+    expect(matches[0]!.line).toBe(2);
+    expect(matches[0]!.column).toBe(1);
+  });
+});
+
+describe("findMatches — context", () => {
+  it("includes the match line as previewLines by default", () => {
+    const content = "one\ntwo\nthree\nfour\nfive\n";
+    const matches = findMatches(content, "three");
+    expect(matches[0]!.previewLines).toEqual([
+      { line: 3, text: "three" },
+    ]);
+  });
+
+  it("respects context option (lines before/after)", () => {
+    const content = "one\ntwo\nthree\nfour\nfive\n";
+    const matches = findMatches(content, "three", { context: 1 });
+    expect(matches[0]!.previewLines).toEqual([
+      { line: 2, text: "two" },
+      { line: 3, text: "three" },
+      { line: 4, text: "four" },
+    ]);
+  });
+
+  it("clamps context at document boundaries", () => {
+    const content = "one\ntwo\nthree\n";
+    const matches = findMatches(content, "one", { context: 2 });
+    expect(matches[0]!.previewLines).toEqual([
+      { line: 1, text: "one" },
+      { line: 2, text: "two" },
+      { line: 3, text: "three" },
+    ]);
+  });
+
+  it("for multi-line matches, includes every match line in previewLines", () => {
+    const content = "a\nfoo\nbar\nend\n";
+    const matches = findMatches(content, "foo\nbar");
+    const lines = matches[0]!.previewLines.map((p) => p.line);
+    expect(lines).toContain(2);
+    expect(lines).toContain(3);
+  });
+});
+
+describe("findMatches — guards and edge cases", () => {
+  it("returns empty for empty query", () => {
+    const matches = findMatches("hello", "");
+    expect(matches).toEqual([]);
+  });
+
+  it("handles content without trailing newline", () => {
+    const content = "no\ntrailing";
+    const matches = findMatches(content, "trailing");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.line).toBe(2);
+  });
+
+  it("does not double-count overlapping matches", () => {
+    // "aaaa" contains "aa" overlappingly at 0,1,2. We use non-overlapping
+    // semantics so search advances past each match.
+    const matches = findMatches("aaaa", "aa");
+    expect(matches).toHaveLength(2);
+  });
+
+  it("Match objects expose a stable shape", () => {
+    const content = "alpha\nbeta\n";
+    const matches: Match[] = findMatches(content, "beta");
+    const m = matches[0]!;
+    expect(typeof m.start).toBe("number");
+    expect(typeof m.end).toBe("number");
+    expect(typeof m.line).toBe("number");
+    expect(typeof m.column).toBe("number");
+    expect(Array.isArray(m.previewLines)).toBe(true);
+  });
+});

--- a/src/lib/match-resolver.ts
+++ b/src/lib/match-resolver.ts
@@ -24,38 +24,10 @@ export type FindOptions = {
 };
 
 function splitLines(content: string): string[] {
-  // Preserves empty trailing line iff the string ends with a newline; for
-  // preview purposes we only need indexable line text without their breaks.
   return content.split("\n");
 }
 
-function lineColumnFromOffset(
-  offset: number,
-  content: string,
-): { line: number; column: number } {
-  let line = 1;
-  let lineStart = 0;
-  for (let i = 0; i < offset; i++) {
-    if (content.charCodeAt(i) === 10) {
-      line++;
-      lineStart = i + 1;
-    }
-  }
-  return { line, column: offset - lineStart + 1 };
-}
-
-function endLineFromOffset(end: number, content: string): number {
-  let line = 1;
-  for (let i = 0; i < end; i++) {
-    if (content.charCodeAt(i) === 10) {
-      line++;
-    }
-  }
-  return line;
-}
-
 function buildPreview(
-  content: string,
   startLine: number,
   endLine: number,
   context: number,
@@ -70,6 +42,12 @@ function buildPreview(
   return out;
 }
 
+/**
+ * Linear scan: track current line and line-start column while advancing
+ * through `indexOf` matches in document order. Each match advances the
+ * cursor only as far as the match's end offset, so total work is O(n)
+ * in `content.length` regardless of match count.
+ */
 export function findMatches(
   content: string,
   query: string,
@@ -78,8 +56,6 @@ export function findMatches(
   if (query.length === 0) return [];
   const context = opts.context ?? 0;
   const lines = splitLines(content);
-  // splitLines on "a\n" gives ["a", ""] — drop the trailing empty entry so
-  // line numbers don't exceed the visible line count.
   const lineCount =
     lines.length > 0 && lines[lines.length - 1] === ""
       ? lines.length - 1
@@ -88,20 +64,42 @@ export function findMatches(
 
   const matches: Match[] = [];
   let from = 0;
+  let cursor = 0;
+  let line = 1;
+  let lineStart = 0;
+
   while (from <= content.length - query.length) {
     const idx = content.indexOf(query, from);
     if (idx === -1) break;
+
+    while (cursor < idx) {
+      if (content.charCodeAt(cursor) === 10) {
+        line++;
+        lineStart = cursor + 1;
+      }
+      cursor++;
+    }
+    const startLine = line;
+    const column = idx - lineStart + 1;
+
     const end = idx + query.length;
-    const { line, column } = lineColumnFromOffset(idx, content);
-    const lastLine = endLineFromOffset(end, content);
+    while (cursor < end) {
+      if (content.charCodeAt(cursor) === 10) {
+        line++;
+        lineStart = cursor + 1;
+      }
+      cursor++;
+    }
+    const lastLine = line;
+
     matches.push({
       start: idx,
       end,
-      line,
+      line: startLine,
       column,
-      previewLines: buildPreview(content, line, lastLine, context, visibleLines),
+      previewLines: buildPreview(startLine, lastLine, context, visibleLines),
     });
-    // Non-overlapping advance: skip past the matched region.
+
     from = end;
   }
   return matches;

--- a/src/lib/match-resolver.ts
+++ b/src/lib/match-resolver.ts
@@ -1,0 +1,108 @@
+export type PreviewLine = {
+  /** 1-indexed line number in the source content. */
+  line: number;
+  /** The line text without its trailing newline. */
+  text: string;
+};
+
+export type Match = {
+  /** UTF-16 code-unit offset in `content` where the match begins. */
+  start: number;
+  /** Exclusive end offset. */
+  end: number;
+  /** 1-indexed line of the match start. */
+  line: number;
+  /** 1-indexed column of the match start. */
+  column: number;
+  /** Snippet around the match — match line plus optional context lines. */
+  previewLines: PreviewLine[];
+};
+
+export type FindOptions = {
+  /** Number of context lines to include before and after the match. Default 0. */
+  context?: number;
+};
+
+function splitLines(content: string): string[] {
+  // Preserves empty trailing line iff the string ends with a newline; for
+  // preview purposes we only need indexable line text without their breaks.
+  return content.split("\n");
+}
+
+function lineColumnFromOffset(
+  offset: number,
+  content: string,
+): { line: number; column: number } {
+  let line = 1;
+  let lineStart = 0;
+  for (let i = 0; i < offset; i++) {
+    if (content.charCodeAt(i) === 10) {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, column: offset - lineStart + 1 };
+}
+
+function endLineFromOffset(end: number, content: string): number {
+  let line = 1;
+  for (let i = 0; i < end; i++) {
+    if (content.charCodeAt(i) === 10) {
+      line++;
+    }
+  }
+  return line;
+}
+
+function buildPreview(
+  content: string,
+  startLine: number,
+  endLine: number,
+  context: number,
+  allLines: string[],
+): PreviewLine[] {
+  const first = Math.max(1, startLine - context);
+  const last = Math.min(allLines.length, endLine + context);
+  const out: PreviewLine[] = [];
+  for (let i = first; i <= last; i++) {
+    out.push({ line: i, text: allLines[i - 1] ?? "" });
+  }
+  return out;
+}
+
+export function findMatches(
+  content: string,
+  query: string,
+  opts: FindOptions = {},
+): Match[] {
+  if (query.length === 0) return [];
+  const context = opts.context ?? 0;
+  const lines = splitLines(content);
+  // splitLines on "a\n" gives ["a", ""] — drop the trailing empty entry so
+  // line numbers don't exceed the visible line count.
+  const lineCount =
+    lines.length > 0 && lines[lines.length - 1] === ""
+      ? lines.length - 1
+      : lines.length;
+  const visibleLines = lines.slice(0, lineCount);
+
+  const matches: Match[] = [];
+  let from = 0;
+  while (from <= content.length - query.length) {
+    const idx = content.indexOf(query, from);
+    if (idx === -1) break;
+    const end = idx + query.length;
+    const { line, column } = lineColumnFromOffset(idx, content);
+    const lastLine = endLineFromOffset(end, content);
+    matches.push({
+      start: idx,
+      end,
+      line,
+      column,
+      previewLines: buildPreview(content, line, lastLine, context, visibleLines),
+    });
+    // Non-overlapping advance: skip past the matched region.
+    from = end;
+  }
+  return matches;
+}

--- a/src/lib/operation-applier.test.ts
+++ b/src/lib/operation-applier.test.ts
@@ -34,7 +34,9 @@ describe("apply — single replace op", () => {
       expect(result.error.kind).toBe("ambiguous_match");
       if (result.error.kind === "ambiguous_match") {
         expect(result.error.matchCount).toBe(2);
-        expect(result.error.previewLines.length).toBeGreaterThan(0);
+        expect(result.error.matches).toHaveLength(2);
+        expect(result.error.matches[0]?.line).toBeGreaterThan(0);
+        expect(result.error.matches[0]?.previewLines.length).toBeGreaterThan(0);
       }
       expect(result.failedAt).toBe(0);
     }

--- a/src/lib/operation-applier.test.ts
+++ b/src/lib/operation-applier.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import { apply, type ApplyResult } from "./operation-applier";
+import type { EditOp } from "./edit-op-schema";
+
+function mkContent(lines: string[]): string {
+  return lines.join("\n") + "\n";
+}
+
+function expectOk(r: ApplyResult): asserts r is Extract<ApplyResult, { ok: true }> {
+  if (!r.ok) {
+    throw new Error(
+      `expected ok=true but got error ${JSON.stringify(r.error)} at op ${r.failedAt}`,
+    );
+  }
+}
+
+describe("apply — single replace op", () => {
+  it("replaces a unique string match", () => {
+    const ops: EditOp[] = [
+      { type: "replace", find: "foo", replace: "bar", replaceAll: false },
+    ];
+    const result = apply("hello foo world\n", ops);
+    expectOk(result);
+    expect(result.content).toBe("hello bar world\n");
+  });
+
+  it("returns ambiguous_match when query matches multiple times without replaceAll", () => {
+    const ops: EditOp[] = [
+      { type: "replace", find: "foo", replace: "bar", replaceAll: false },
+    ];
+    const result = apply("foo foo\n", ops);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("ambiguous_match");
+      if (result.error.kind === "ambiguous_match") {
+        expect(result.error.matchCount).toBe(2);
+        expect(result.error.previewLines.length).toBeGreaterThan(0);
+      }
+      expect(result.failedAt).toBe(0);
+    }
+  });
+
+  it("replaceAll: true replaces every occurrence", () => {
+    const ops: EditOp[] = [
+      { type: "replace", find: "foo", replace: "bar", replaceAll: true },
+    ];
+    const result = apply("foo foo foo\n", ops);
+    expectOk(result);
+    expect(result.content).toBe("bar bar bar\n");
+  });
+
+  it("returns no_match when query is absent", () => {
+    const ops: EditOp[] = [
+      { type: "replace", find: "missing", replace: "x", replaceAll: false },
+    ];
+    const result = apply("hello\n", ops);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("no_match");
+      expect(result.failedAt).toBe(0);
+    }
+  });
+});
+
+describe("apply — line-addressed ops, single", () => {
+  const content = mkContent(["one", "two", "three", "four"]);
+
+  it("insertAfterLine inserts after the given 1-indexed line", () => {
+    const result = apply(content, [
+      { type: "insertAfterLine", line: 2, content: "INSERTED" },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["one", "two", "INSERTED", "three", "four"]));
+  });
+
+  it("insertAfterLine line=0 inserts at the very top", () => {
+    const result = apply(content, [
+      { type: "insertAfterLine", line: 0, content: "TOP" },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["TOP", "one", "two", "three", "four"]));
+  });
+
+  it("insertBeforeLine inserts before the given 1-indexed line", () => {
+    const result = apply(content, [
+      { type: "insertBeforeLine", line: 3, content: "BEFORE" },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["one", "two", "BEFORE", "three", "four"]));
+  });
+
+  it("deleteLineRange removes the inclusive range", () => {
+    const result = apply(content, [
+      { type: "deleteLineRange", from: 2, to: 3 },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["one", "four"]));
+  });
+
+  it("replaceLineRange replaces the inclusive range with new content", () => {
+    const result = apply(content, [
+      { type: "replaceLineRange", from: 2, to: 3, content: "ALPHA\nBETA" },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["one", "ALPHA", "BETA", "four"]));
+  });
+
+  it("returns line_out_of_range when line exceeds doc length", () => {
+    const result = apply(content, [
+      { type: "insertAfterLine", line: 99, content: "X" },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("line_out_of_range");
+    }
+  });
+
+  it("returns range_out_of_range when 'to' exceeds doc length", () => {
+    const result = apply(content, [
+      { type: "deleteLineRange", from: 2, to: 99 },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("range_out_of_range");
+    }
+  });
+});
+
+describe("apply — batch with line-addressed ops resolving against snapshot", () => {
+  const content = mkContent(["a", "b", "c", "d", "e"]);
+
+  it("two deleteLineRange ops both resolve against the original line numbers", () => {
+    // Naive left-to-right would shift the second range. Snapshot semantics
+    // means both resolve against {a,b,c,d,e}: delete lines 1 and lines 4.
+    const result = apply(content, [
+      { type: "deleteLineRange", from: 1, to: 1 },
+      { type: "deleteLineRange", from: 4, to: 4 },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["b", "c", "e"]));
+  });
+
+  it("insertAfterLine ops resolve against snapshot line numbers", () => {
+    const result = apply(content, [
+      { type: "insertAfterLine", line: 1, content: "X" },
+      { type: "insertAfterLine", line: 3, content: "Y" },
+    ]);
+    expectOk(result);
+    // Both anchor to original line numbers: after line 1 ("a") and after line 3 ("c").
+    expect(result.content).toBe(mkContent(["a", "X", "b", "c", "Y", "d", "e"]));
+  });
+
+  it("rejects overlapping line-addressed ops in the same batch", () => {
+    const result = apply(content, [
+      { type: "deleteLineRange", from: 2, to: 3 },
+      { type: "replaceLineRange", from: 3, to: 4, content: "X" },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("overlapping_line_ops");
+    }
+  });
+});
+
+describe("apply — mixed line and string ops", () => {
+  it("string ops resolve against running content (post-line-ops)", () => {
+    // Line op converts "ALPHA" -> "ALPHA-X". String op then sees the new text.
+    const content = mkContent(["one ALPHA", "two", "three"]);
+    const result = apply(content, [
+      { type: "replaceLineRange", from: 1, to: 1, content: "one ALPHA-X" },
+      { type: "replace", find: "ALPHA-X", replace: "BETA", replaceAll: false },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["one BETA", "two", "three"]));
+  });
+
+  it("string op against text not visible in snapshot still works (running-content semantics)", () => {
+    // The first op produces text the second op then matches.
+    const content = mkContent(["foo", "bar"]);
+    const result = apply(content, [
+      { type: "insertAfterLine", line: 1, content: "NEEDLE" },
+      { type: "replace", find: "NEEDLE", replace: "FOUND", replaceAll: false },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["foo", "FOUND", "bar"]));
+  });
+});
+
+describe("apply — atomicity", () => {
+  it("returns the original content unchanged when any op fails", () => {
+    const content = mkContent(["one", "two", "three"]);
+    const result = apply(content, [
+      { type: "insertAfterLine", line: 1, content: "X" },
+      { type: "replace", find: "missing", replace: "y", replaceAll: false },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failedAt).toBe(1);
+      expect(result.error.kind).toBe("no_match");
+    }
+  });
+});
+
+describe("apply — empty ops batch", () => {
+  it("returns the content unchanged for an empty batch", () => {
+    // Defensive: parseEditOps rejects empty arrays at the boundary, but apply
+    // should be safe to call with [].
+    const content = "hello\n";
+    const result = apply(content, []);
+    expectOk(result);
+    expect(result.content).toBe(content);
+  });
+});

--- a/src/lib/operation-applier.ts
+++ b/src/lib/operation-applier.ts
@@ -1,0 +1,241 @@
+import { findMatches, type PreviewLine } from "./match-resolver";
+import type {
+  EditOp,
+  InsertAfterLineOp,
+  InsertBeforeLineOp,
+  DeleteLineRangeOp,
+  ReplaceLineRangeOp,
+} from "./edit-op-schema";
+
+export type ApplierError =
+  | { kind: "no_match"; query: string }
+  | {
+      kind: "ambiguous_match";
+      query: string;
+      matchCount: number;
+      previewLines: PreviewLine[];
+    }
+  | { kind: "line_out_of_range"; line: number; documentLines: number }
+  | {
+      kind: "range_out_of_range";
+      from: number;
+      to: number;
+      documentLines: number;
+    }
+  | { kind: "overlapping_line_ops"; conflictsWith: number };
+
+export type ApplyResult =
+  | { ok: true; content: string }
+  | { ok: false; failedAt: number; error: ApplierError };
+
+type LineAddressedOp =
+  | InsertAfterLineOp
+  | InsertBeforeLineOp
+  | DeleteLineRangeOp
+  | ReplaceLineRangeOp;
+
+type ResolvedRange = {
+  start: number;
+  end: number;
+  replacement: string;
+};
+
+function isLineOp(op: EditOp): op is LineAddressedOp {
+  return op.type !== "replace";
+}
+
+function visibleLineCount(content: string): number {
+  if (content.length === 0) return 0;
+  let count = 1;
+  for (let i = 0; i < content.length; i++) {
+    if (content.charCodeAt(i) === 10) {
+      // Trailing newline doesn't introduce an additional visible line.
+      if (i === content.length - 1) break;
+      count++;
+    }
+  }
+  return count;
+}
+
+function lineStartOffset(content: string, line: number): number {
+  if (line <= 1) return 0;
+  let currentLine = 1;
+  for (let i = 0; i < content.length; i++) {
+    if (content.charCodeAt(i) === 10) {
+      currentLine++;
+      if (currentLine === line) return i + 1;
+    }
+  }
+  // Caller guards against out-of-range; reaching here means line === lineCount+1
+  // (one past the end), which we represent as the end of the content.
+  return content.length;
+}
+
+function resolveLineOp(
+  op: LineAddressedOp,
+  snapshot: string,
+  visibleCount: number,
+): { ok: true; range: ResolvedRange } | { ok: false; error: ApplierError } {
+  switch (op.type) {
+    case "insertAfterLine": {
+      if (op.line < 0 || op.line > visibleCount) {
+        return {
+          ok: false,
+          error: {
+            kind: "line_out_of_range",
+            line: op.line,
+            documentLines: visibleCount,
+          },
+        };
+      }
+      const insertAt =
+        op.line === visibleCount
+          ? snapshot.length
+          : lineStartOffset(snapshot, op.line + 1);
+      // Tail-of-file insertion needs a leading newline if the snapshot doesn't
+      // end with one — otherwise the inserted line would fuse with the prior.
+      const needsLeading =
+        op.line === visibleCount &&
+        snapshot.length > 0 &&
+        snapshot.charCodeAt(snapshot.length - 1) !== 10;
+      const replacement = (needsLeading ? "\n" : "") + op.content + "\n";
+      return { ok: true, range: { start: insertAt, end: insertAt, replacement } };
+    }
+    case "insertBeforeLine": {
+      if (op.line < 1 || op.line > visibleCount) {
+        return {
+          ok: false,
+          error: {
+            kind: "line_out_of_range",
+            line: op.line,
+            documentLines: visibleCount,
+          },
+        };
+      }
+      const insertAt = lineStartOffset(snapshot, op.line);
+      return {
+        ok: true,
+        range: { start: insertAt, end: insertAt, replacement: op.content + "\n" },
+      };
+    }
+    case "deleteLineRange":
+    case "replaceLineRange": {
+      if (op.from < 1 || op.to > visibleCount) {
+        return {
+          ok: false,
+          error: {
+            kind: "range_out_of_range",
+            from: op.from,
+            to: op.to,
+            documentLines: visibleCount,
+          },
+        };
+      }
+      const start = lineStartOffset(snapshot, op.from);
+      const end =
+        op.to === visibleCount
+          ? snapshot.length
+          : lineStartOffset(snapshot, op.to + 1);
+      let replacement: string;
+      if (op.type === "deleteLineRange") {
+        replacement = "";
+      } else {
+        // Empty content collapses to deletion (no empty line left behind).
+        replacement = op.content === "" ? "" : op.content + "\n";
+      }
+      return { ok: true, range: { start, end, replacement } };
+    }
+  }
+}
+
+export function apply(snapshot: string, ops: EditOp[]): ApplyResult {
+  if (ops.length === 0) return { ok: true, content: snapshot };
+
+  const visibleCount = visibleLineCount(snapshot);
+
+  type Resolved = { opIndex: number; range: ResolvedRange };
+  const resolvedLineOps: Resolved[] = [];
+  for (let i = 0; i < ops.length; i++) {
+    const op = ops[i]!;
+    if (!isLineOp(op)) continue;
+    const r = resolveLineOp(op, snapshot, visibleCount);
+    if (!r.ok) return { ok: false, failedAt: i, error: r.error };
+    resolvedLineOps.push({ opIndex: i, range: r.range });
+  }
+
+  for (let i = 0; i < resolvedLineOps.length; i++) {
+    for (let j = i + 1; j < resolvedLineOps.length; j++) {
+      const a = resolvedLineOps[i]!.range;
+      const b = resolvedLineOps[j]!.range;
+      if (a.start < b.end && b.start < a.end) {
+        return {
+          ok: false,
+          failedAt: resolvedLineOps[j]!.opIndex,
+          error: {
+            kind: "overlapping_line_ops",
+            conflictsWith: resolvedLineOps[i]!.opIndex,
+          },
+        };
+      }
+    }
+  }
+
+  // Apply line ops right-to-left so left-side offsets remain stable.
+  // Tie-break: later input index applied first => earlier input ends up first
+  // in the output for ops sharing an insertion offset.
+  const sorted = [...resolvedLineOps].sort((a, b) => {
+    if (b.range.start !== a.range.start) return b.range.start - a.range.start;
+    return b.opIndex - a.opIndex;
+  });
+  let running = snapshot;
+  for (const { range } of sorted) {
+    running =
+      running.slice(0, range.start) + range.replacement + running.slice(range.end);
+  }
+
+  for (let i = 0; i < ops.length; i++) {
+    const op = ops[i]!;
+    if (op.type !== "replace") continue;
+    if (op.replaceAll) {
+      const matches = findMatches(running, op.find);
+      if (matches.length === 0) {
+        return {
+          ok: false,
+          failedAt: i,
+          error: { kind: "no_match", query: op.find },
+        };
+      }
+      for (let m = matches.length - 1; m >= 0; m--) {
+        const match = matches[m]!;
+        running =
+          running.slice(0, match.start) + op.replace + running.slice(match.end);
+      }
+    } else {
+      const matches = findMatches(running, op.find, { context: 1 });
+      if (matches.length === 0) {
+        return {
+          ok: false,
+          failedAt: i,
+          error: { kind: "no_match", query: op.find },
+        };
+      }
+      if (matches.length > 1) {
+        return {
+          ok: false,
+          failedAt: i,
+          error: {
+            kind: "ambiguous_match",
+            query: op.find,
+            matchCount: matches.length,
+            previewLines: matches.flatMap((m) => m.previewLines),
+          },
+        };
+      }
+      const match = matches[0]!;
+      running =
+        running.slice(0, match.start) + op.replace + running.slice(match.end);
+    }
+  }
+
+  return { ok: true, content: running };
+}

--- a/src/lib/operation-applier.ts
+++ b/src/lib/operation-applier.ts
@@ -1,4 +1,10 @@
 import { findMatches, type PreviewLine } from "./match-resolver";
+
+export type MatchPreview = {
+  line: number;
+  column: number;
+  previewLines: PreviewLine[];
+};
 import type {
   EditOp,
   InsertAfterLineOp,
@@ -13,7 +19,7 @@ export type ApplierError =
       kind: "ambiguous_match";
       query: string;
       matchCount: number;
-      previewLines: PreviewLine[];
+      matches: MatchPreview[];
     }
   | { kind: "line_out_of_range"; line: number; documentLines: number }
   | {
@@ -227,7 +233,11 @@ export function apply(snapshot: string, ops: EditOp[]): ApplyResult {
             kind: "ambiguous_match",
             query: op.find,
             matchCount: matches.length,
-            previewLines: matches.flatMap((m) => m.previewLines),
+            matches: matches.map((m) => ({
+              line: m.line,
+              column: m.column,
+              previewLines: m.previewLines,
+            })),
           },
         };
       }

--- a/src/lib/operation-applier.ts
+++ b/src/lib/operation-applier.ts
@@ -1,10 +1,4 @@
 import { findMatches, type PreviewLine } from "./match-resolver";
-
-export type MatchPreview = {
-  line: number;
-  column: number;
-  previewLines: PreviewLine[];
-};
 import type {
   EditOp,
   InsertAfterLineOp,
@@ -12,6 +6,20 @@ import type {
   DeleteLineRangeOp,
   ReplaceLineRangeOp,
 } from "./edit-op-schema";
+
+export type MatchPreview = {
+  line: number;
+  column: number;
+  previewLines: PreviewLine[];
+};
+
+/**
+ * Cap on `matches` returned in an ambiguous_match error. Short queries can
+ * match many thousands of times in a 1MB doc; previews are useful for
+ * disambiguation only when they fit in a glance. `matchCount` always
+ * reports the true total so the caller knows previews were truncated.
+ */
+const MAX_AMBIGUOUS_PREVIEWS = 5;
 
 export type ApplierError =
   | { kind: "no_match"; query: string }
@@ -203,19 +211,16 @@ export function apply(snapshot: string, ops: EditOp[]): ApplyResult {
     const op = ops[i]!;
     if (op.type !== "replace") continue;
     if (op.replaceAll) {
-      const matches = findMatches(running, op.find);
-      if (matches.length === 0) {
+      if (!running.includes(op.find)) {
         return {
           ok: false,
           failedAt: i,
           error: { kind: "no_match", query: op.find },
         };
       }
-      for (let m = matches.length - 1; m >= 0; m--) {
-        const match = matches[m]!;
-        running =
-          running.slice(0, match.start) + op.replace + running.slice(match.end);
-      }
+      // Native split/join is linear in content + replacements and avoids
+      // building per-match preview metadata we wouldn't surface anyway.
+      running = running.split(op.find).join(op.replace);
     } else {
       const matches = findMatches(running, op.find, { context: 1 });
       if (matches.length === 0) {
@@ -233,7 +238,7 @@ export function apply(snapshot: string, ops: EditOp[]): ApplyResult {
             kind: "ambiguous_match",
             query: op.find,
             matchCount: matches.length,
-            matches: matches.map((m) => ({
+            matches: matches.slice(0, MAX_AMBIGUOUS_PREVIEWS).map((m) => ({
               line: m.line,
               column: m.column,
               previewLines: m.previewLines,


### PR DESCRIPTION
Closes #46.

## Summary

Adds the `/api/agent/*` namespace — a parallel API surface shaped for AI coding agents to read, create, and surgically edit markdown on this service. Existing `/api/*` (CLI/scripting) is untouched.

Three pure modules + three HTTP routes + a SKILL.md update.

### Pure modules (in `src/lib/`)

- **`edit-op-schema.ts`** — discriminated union for the 5 phase-1 ops (`replace`, `insertAfterLine`, `insertBeforeLine`, `deleteLineRange`, `replaceLineRange`) plus `parseEditOp` / `parseEditOps` runtime validators that follow the project's manual-validation pattern (no zod added).
- **`match-resolver.ts`** — `findMatches(content, query, opts)` returning 1-indexed line/column plus optional context window. Non-overlapping advance, multi-line query support.
- **`operation-applier.ts`** — `apply(snapshot, ops[])` with the snapshot/running resolution rule baked in: line-addressed ops resolve against the batch-start snapshot (right-to-left application keeps left offsets stable), string-addressed ops resolve against running content. Atomic — any failure returns the original snapshot untouched plus a structured `ApplierError`. Overlapping line-addressed ops are rejected with `overlapping_line_ops` and the conflicting op index.

### HTTP routes (in `src/app/api/agent/`)

- **`POST /api/agent/docs/[slug]/edits`** — atomic batch. Calls `OperationApplier.apply` then `DocMutationPath.writeDocContent({source: 'agent', ...})`. Preserves the no-op invariant from PR #47 (skips the chokepoint write when result === input). 1 MB cap. Structured 409 on resolution failure with `failedAt` and per-error fields.
- **`GET /api/agent/docs/[slug]`** — returns `{id, slug, title, kind, content, createdAt, updatedAt}` for the owned doc.
- **`POST /api/agent/docs`** — JSON-only mirror of `/api/upload` for surface symmetry. Same auth, same limits.

All three reuse `requireOwnedDoc` from #47 for auth + ownership.

### Structured 409 error shape

After smoke-testing as the agent, `previewLines` was restructured from a flat list with cross-match duplicates to `matches: [{line, column, previewLines}]` so each location owns its own context window (commit `ac344e7`). Saves the agent from mentally deduplicating overlapping previews when picking a unique find string.

### SKILL.md update

`~/.claude/skills/md-upload/SKILL.md` extended (not split) with a "Targeted edits (agent ops API)" section, "Create (JSON-only)" section, fetch endpoint, op-shape table, error-recovery table, and a "Shell trap" note about `echo` interpreting `\n` in zsh/dash. Frontmatter description updated to advertise edit/fetch triggers.

### Tests

83 new tests across the 3 pure modules (62) and 3 routes (21). Full suite: 248/248 green. Typecheck + lint clean.

### Smoke verification

Fresh dev-server run: created one doc via `POST /api/agent/docs`, applied 3 sequential agent ops producing 3 revisions, triggered `ambiguous_match` and verified the new `matches[]` shape — all flowed naturally without consulting the codebase.

### Out of scope (Phase 2 candidates)

- `If-Match: <updatedAt>` optimistic concurrency
- `dryRun: true` on `/edits`
- Heading-addressed ops (`replaceSection`)
- Cross-doc batch (`POST /api/agent/edits`)
- Owner-scoped search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document management API endpoints to create, retrieve, and edit documents
  * Implemented text editing operations including find/replace, line insertions, deletions, and replacements
  * Automatic title resolution and search text generation for documents
  * Enforced 1MB content size limit for safety
  * Added revision tracking with metadata for content changes

* **Tests**
  * Comprehensive test coverage for all new API endpoints and edit operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->