### PR TITLE
feat(agent-api): save-shape DX (setContent, to:-1, lineCount)

### DIFF
--- a/src/app/api/agent/docs/[slug]/edits/route.test.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.test.ts
@@ -248,6 +248,84 @@ describe("POST /api/agent/docs/[slug]/edits — structured 409 errors", () => {
   });
 });
 
+describe("POST /api/agent/docs/[slug]/edits — setContent", () => {
+  it("rewrites the entire body and records an agent revision", async () => {
+    const { token, doc } = await setupAuthorizedDoc("# Old\n\nbody\n");
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [{ type: "setContent", content: "# New\n\nbody2\n" }],
+        summary: "full save",
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      doc: { content: string };
+      revisionId: string;
+    };
+    expect(body.doc.content).toBe("# New\n\nbody2\n");
+    expect(body.revisionId).toMatch(/^rv_/);
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(1);
+    expect(listed.revisions[0]?.source).toBe("agent");
+  });
+
+  it("re-derives title from the new H1 (matches upload semantics)", async () => {
+    const { token, doc } = await setupAuthorizedDoc("# Old H1\n\nbody\n");
+    const res = await postReq(
+      doc.slug,
+      { ops: [{ type: "setContent", content: "# Brand New H1\n\nfresh\n" }] },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { doc: { title: string } };
+    expect(body.doc.title).toBe("Brand New H1");
+  });
+
+  it("rejects setContent mixed with other ops", async () => {
+    const { token, doc } = await setupAuthorizedDoc("a\n");
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [
+          { type: "setContent", content: "x" },
+          { type: "replace", find: "a", replace: "b" },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/agent/docs/[slug]/edits — to: -1 sentinel", () => {
+  it("replaceLineRange from: 1, to: -1 replaces the whole doc in one call", async () => {
+    const { token, doc } = await setupAuthorizedDoc(
+      "old line 1\nold line 2\nold line 3\n",
+    );
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [
+          {
+            type: "replaceLineRange",
+            from: 1,
+            to: -1,
+            content: "brand new body",
+          },
+        ],
+        summary: "replace via -1 sentinel",
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { doc: { content: string } };
+    expect(body.doc.content).toBe("brand new body\n");
+  });
+});
+
 describe("POST /api/agent/docs/[slug]/edits — content size limit", () => {
   it("rejects ops that would push content past 1 MB", async () => {
     const { token, doc } = await setupAuthorizedDoc("seed\n");

--- a/src/app/api/agent/docs/[slug]/edits/route.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.ts
@@ -125,10 +125,20 @@ export async function POST(
     );
   }
 
+  // setContent is a "save as" — re-derive title from the new H1 like upload
+  // does, so a fresh body doesn't keep an unrelated old title. For partial
+  // edits, preserve the existing title (resolveTitle with the old title as
+  // override is idempotent unless the H1 string itself changed).
+  const isSetContent =
+    parsed.ops.length === 1 && parsed.ops[0]!.type === "setContent";
+  const newTitle = isSetContent
+    ? resolveTitle(result.content, undefined)
+    : resolveTitle(result.content, doc.title);
+
   const writeResult = await writeDocContent({
     docId: doc.id,
     newContent: result.content,
-    newTitle: resolveTitle(result.content, doc.title),
+    newTitle,
     newSearchText: stripMarkdown(result.content),
     summary,
     source: "agent",

--- a/src/app/api/agent/docs/[slug]/route.test.ts
+++ b/src/app/api/agent/docs/[slug]/route.test.ts
@@ -49,7 +49,7 @@ function getReq(slug: string, token: string | null) {
 }
 
 describe("GET /api/agent/docs/[slug]", () => {
-  it("returns 200 with content and updatedAt for an owned doc", async () => {
+  it("returns 200 with content, updatedAt, and lineCount for an owned doc", async () => {
     const { token, doc } = await setupAuthorizedDoc("# Hello\n\nbody\n", "Hi");
     const res = await getReq(doc.slug, token.plaintext);
     expect(res.status).toBe(200);
@@ -59,12 +59,29 @@ describe("GET /api/agent/docs/[slug]", () => {
       kind: string | null;
       content: string;
       updatedAt: string;
+      lineCount: number;
     };
     expect(body.slug).toBe(doc.slug);
     expect(body.title).toBe("Hi");
     expect(body.content).toBe("# Hello\n\nbody\n");
     expect(typeof body.updatedAt).toBe("string");
     expect(new Date(body.updatedAt).getTime()).toBeGreaterThan(0);
+    // 3 visible lines: "# Hello", "", "body" (trailing newline doesn't count).
+    expect(body.lineCount).toBe(3);
+  });
+
+  it("lineCount matches the applier's view (trailing newline irrelevant)", async () => {
+    const { token, doc } = await setupAuthorizedDoc("a\nb\nc\n", "T");
+    const res = await getReq(doc.slug, token.plaintext);
+    const body = (await res.json()) as { lineCount: number };
+    expect(body.lineCount).toBe(3);
+  });
+
+  it("lineCount is 0 for an empty doc", async () => {
+    const { token, doc } = await setupAuthorizedDoc("", "Empty");
+    const res = await getReq(doc.slug, token.plaintext);
+    const body = (await res.json()) as { lineCount: number };
+    expect(body.lineCount).toBe(0);
   });
 
   it("returns 401 without auth", async () => {

--- a/src/app/api/agent/docs/[slug]/route.ts
+++ b/src/app/api/agent/docs/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { requireOwnedDoc } from "@/lib/route-helpers";
+import { visibleLineCount } from "@/lib/operation-applier";
 
 export async function GET(
   req: NextRequest,
@@ -18,6 +19,10 @@ export async function GET(
       kind: doc.kind,
       tags: doc.tags,
       content: doc.content,
+      // Surfaced so agents don't have to re-implement the line-count rule
+      // (and don't get bit by trailing-newline off-by-ones when planning
+      // line-addressed ops).
+      lineCount: visibleLineCount(doc.content),
       createdAt: doc.createdAt,
       updatedAt: doc.updatedAt,
     }),

--- a/src/lib/edit-op-schema.test.ts
+++ b/src/lib/edit-op-schema.test.ts
@@ -201,6 +201,61 @@ describe("parseEditOp — deleteLineRange", () => {
   });
 });
 
+describe("parseEditOp — setContent", () => {
+  it("accepts a setContent op with content", () => {
+    const result = parseEditOp({ type: "setContent", content: "new body" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.op).toEqual({ type: "setContent", content: "new body" });
+    }
+  });
+
+  it("accepts setContent with empty string (empties the doc)", () => {
+    const result = parseEditOp({ type: "setContent", content: "" });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects setContent with non-string content", () => {
+    const result = parseEditOp({ type: "setContent", content: 42 });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseEditOp — to: -1 sentinel", () => {
+  it("accepts deleteLineRange with to: -1 (means end-of-doc)", () => {
+    const result = parseEditOp({ type: "deleteLineRange", from: 2, to: -1 });
+    expect(result.ok).toBe(true);
+    if (result.ok && result.op.type === "deleteLineRange") {
+      expect(result.op.to).toBe(-1);
+    }
+  });
+
+  it("accepts replaceLineRange with to: -1", () => {
+    const result = parseEditOp({
+      type: "replaceLineRange",
+      from: 1,
+      to: -1,
+      content: "x",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("does NOT relax the from > to check when to is a positive integer", () => {
+    const result = parseEditOp({ type: "deleteLineRange", from: 5, to: 2 });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects to: -2 or other negative values", () => {
+    const result = parseEditOp({ type: "deleteLineRange", from: 1, to: -2 });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects to: 0", () => {
+    const result = parseEditOp({ type: "deleteLineRange", from: 1, to: 0 });
+    expect(result.ok).toBe(false);
+  });
+});
+
 describe("parseEditOp — replaceLineRange", () => {
   it("accepts a valid replaceLineRange", () => {
     const result = parseEditOp({
@@ -268,6 +323,22 @@ describe("parseEditOp — discriminator and shape", () => {
     const result = parseEditOp({ type: "moveLines", from: 1, to: 2 });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toMatch(/type|unknown/i);
+  });
+});
+
+describe("parseEditOps batch — setContent exclusivity", () => {
+  it("rejects a batch where setContent is mixed with other ops", () => {
+    const result = parseEditOps([
+      { type: "setContent", content: "x" },
+      { type: "replace", find: "a", replace: "b" },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/setContent.*alone|exclusive/i);
+  });
+
+  it("accepts a batch consisting solely of setContent", () => {
+    const result = parseEditOps([{ type: "setContent", content: "x" }]);
+    expect(result.ok).toBe(true);
   });
 });
 

--- a/src/lib/edit-op-schema.ts
+++ b/src/lib/edit-op-schema.ts
@@ -23,6 +23,7 @@ export type DeleteLineRangeOp = {
   type: "deleteLineRange";
   /** 1-indexed inclusive. */
   from: number;
+  /** 1-indexed inclusive, or `-1` to mean end-of-document. */
   to: number;
 };
 
@@ -30,7 +31,19 @@ export type ReplaceLineRangeOp = {
   type: "replaceLineRange";
   /** 1-indexed inclusive. */
   from: number;
+  /** 1-indexed inclusive, or `-1` to mean end-of-document. */
   to: number;
+  content: string;
+};
+
+/**
+ * Replaces the entire document body in one op. The "save as" verb. Must be
+ * the only op in its batch — mixing with other ops is rejected at parse time
+ * since their resolution semantics (snapshot vs running) become ill-defined
+ * once the whole body is wiped.
+ */
+export type SetContentOp = {
+  type: "setContent";
   content: string;
 };
 
@@ -39,7 +52,8 @@ export type EditOp =
   | InsertAfterLineOp
   | InsertBeforeLineOp
   | DeleteLineRangeOp
-  | ReplaceLineRangeOp;
+  | ReplaceLineRangeOp
+  | SetContentOp;
 
 export type ParseResult<T> =
   | { ok: true; op: T }
@@ -55,7 +69,15 @@ const KNOWN_TYPES = new Set([
   "insertBeforeLine",
   "deleteLineRange",
   "replaceLineRange",
+  "setContent",
 ]);
+
+export const TO_END_SENTINEL = -1;
+
+function isToValue(v: unknown): v is number {
+  if (typeof v !== "number" || !Number.isInteger(v)) return false;
+  return v === TO_END_SENTINEL || v >= 1;
+}
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
@@ -120,10 +142,14 @@ function parseDeleteRange(
   if (!isPositiveInteger(input.from)) {
     return { ok: false, error: "deleteLineRange: from must be an integer >= 1" };
   }
-  if (!isPositiveInteger(input.to)) {
-    return { ok: false, error: "deleteLineRange: to must be an integer >= 1" };
+  if (!isToValue(input.to)) {
+    return {
+      ok: false,
+      error:
+        "deleteLineRange: to must be an integer >= 1 (or -1 for end-of-document)",
+    };
   }
-  if (input.from > input.to) {
+  if (input.to !== TO_END_SENTINEL && input.from > input.to) {
     return {
       ok: false,
       error: "deleteLineRange: from must be <= to (invalid range)",
@@ -141,10 +167,14 @@ function parseReplaceRange(
   if (!isPositiveInteger(input.from)) {
     return { ok: false, error: "replaceLineRange: from must be an integer >= 1" };
   }
-  if (!isPositiveInteger(input.to)) {
-    return { ok: false, error: "replaceLineRange: to must be an integer >= 1" };
+  if (!isToValue(input.to)) {
+    return {
+      ok: false,
+      error:
+        "replaceLineRange: to must be an integer >= 1 (or -1 for end-of-document)",
+    };
   }
-  if (input.from > input.to) {
+  if (input.to !== TO_END_SENTINEL && input.from > input.to) {
     return {
       ok: false,
       error: "replaceLineRange: from must be <= to (invalid range)",
@@ -162,6 +192,15 @@ function parseReplaceRange(
       content: input.content,
     },
   };
+}
+
+function parseSetContent(
+  input: Record<string, unknown>,
+): ParseResult<SetContentOp> {
+  if (typeof input.content !== "string") {
+    return { ok: false, error: "setContent: content must be a string" };
+  }
+  return { ok: true, op: { type: "setContent", content: input.content } };
 }
 
 export function parseEditOp(input: unknown): ParseResult<EditOp> {
@@ -186,6 +225,8 @@ export function parseEditOp(input: unknown): ParseResult<EditOp> {
       return parseDeleteRange(input);
     case "replaceLineRange":
       return parseReplaceRange(input);
+    case "setContent":
+      return parseSetContent(input);
     default:
       return { ok: false, error: `unknown op type: ${type}` };
   }
@@ -205,6 +246,16 @@ export function parseEditOps(input: unknown): ParseBatchResult {
       return { ok: false, error: `ops[${i}]: ${result.error}` };
     }
     ops.push(result.op);
+  }
+  // setContent rewrites the whole body; mixing it with other ops makes
+  // their resolution rules (snapshot vs running) ill-defined. Require it
+  // to stand alone.
+  const hasSetContent = ops.some((op) => op.type === "setContent");
+  if (hasSetContent && ops.length > 1) {
+    return {
+      ok: false,
+      error: "setContent must be the only op in its batch (exclusive)",
+    };
   }
   return { ok: true, ops };
 }

--- a/src/lib/operation-applier.test.ts
+++ b/src/lib/operation-applier.test.ts
@@ -203,6 +203,50 @@ describe("apply — atomicity", () => {
   });
 });
 
+describe("apply — setContent op", () => {
+  it("replaces the entire document body", () => {
+    const result = apply("# Old\n\nbody\n", [
+      { type: "setContent", content: "# New\n\nbody2\n" },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe("# New\n\nbody2\n");
+  });
+
+  it("accepts empty content (empties the doc)", () => {
+    const result = apply("# Old\n", [{ type: "setContent", content: "" }]);
+    expectOk(result);
+    expect(result.content).toBe("");
+  });
+});
+
+describe("apply — to: -1 sentinel", () => {
+  const content = mkContent(["a", "b", "c", "d", "e"]);
+
+  it("deleteLineRange to: -1 deletes through end of doc", () => {
+    const result = apply(content, [
+      { type: "deleteLineRange", from: 3, to: -1 },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["a", "b"]));
+  });
+
+  it("replaceLineRange to: -1 replaces from N through end with new content", () => {
+    const result = apply(content, [
+      { type: "replaceLineRange", from: 1, to: -1, content: "X\nY" },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["X", "Y"]));
+  });
+
+  it("from: 1, to: -1 replaces the whole doc (alternative to setContent)", () => {
+    const result = apply(content, [
+      { type: "replaceLineRange", from: 1, to: -1, content: "ALL NEW" },
+    ]);
+    expectOk(result);
+    expect(result.content).toBe(mkContent(["ALL NEW"]));
+  });
+});
+
 describe("apply — empty ops batch", () => {
   it("returns the content unchanged for an empty batch", () => {
     // Defensive: parseEditOps rejects empty arrays at the boundary, but apply

--- a/src/lib/operation-applier.ts
+++ b/src/lib/operation-applier.ts
@@ -48,6 +48,8 @@ type LineAddressedOp =
   | DeleteLineRangeOp
   | ReplaceLineRangeOp;
 
+const TO_END_SENTINEL = -1;
+
 type ResolvedRange = {
   start: number;
   end: number;
@@ -55,10 +57,22 @@ type ResolvedRange = {
 };
 
 function isLineOp(op: EditOp): op is LineAddressedOp {
-  return op.type !== "replace";
+  return (
+    op.type === "insertAfterLine" ||
+    op.type === "insertBeforeLine" ||
+    op.type === "deleteLineRange" ||
+    op.type === "replaceLineRange"
+  );
 }
 
-function visibleLineCount(content: string): number {
+/**
+ * The number of lines an editor would display for `content`. A trailing
+ * newline does NOT count as starting an additional empty line.
+ *
+ * Exported so the GET endpoint can surface `lineCount` without re-implementing
+ * the count rule (and without diverging from what the applier uses internally).
+ */
+export function visibleLineCount(content: string): number {
   if (content.length === 0) return 0;
   let count = 1;
   for (let i = 0; i < content.length; i++) {
@@ -134,7 +148,10 @@ function resolveLineOp(
     }
     case "deleteLineRange":
     case "replaceLineRange": {
-      if (op.from < 1 || op.to > visibleCount) {
+      // -1 sentinel resolves to the last visible line. Surfacing this as the
+      // resolved value also keeps overlap detection accurate.
+      const resolvedTo = op.to === TO_END_SENTINEL ? visibleCount : op.to;
+      if (op.from < 1 || resolvedTo > visibleCount || op.from > resolvedTo) {
         return {
           ok: false,
           error: {
@@ -147,9 +164,9 @@ function resolveLineOp(
       }
       const start = lineStartOffset(snapshot, op.from);
       const end =
-        op.to === visibleCount
+        resolvedTo === visibleCount
           ? snapshot.length
-          : lineStartOffset(snapshot, op.to + 1);
+          : lineStartOffset(snapshot, resolvedTo + 1);
       let replacement: string;
       if (op.type === "deleteLineRange") {
         replacement = "";
@@ -164,6 +181,12 @@ function resolveLineOp(
 
 export function apply(snapshot: string, ops: EditOp[]): ApplyResult {
   if (ops.length === 0) return { ok: true, content: snapshot };
+
+  // setContent is exclusive in its batch (enforced at parse time). Short-
+  // circuit here so the line/string resolution paths don't have to consider it.
+  if (ops.length === 1 && ops[0]!.type === "setContent") {
+    return { ok: true, content: ops[0]!.content };
+  }
 
   const visibleCount = visibleLineCount(snapshot);
 


### PR DESCRIPTION
Follow-up to PR #48. Addresses the three concrete DX gaps an agent hit while doing a full-doc sync (feedback at https://md.niftymonkey.dev/api/raw/kzKAmYhQ).

## What's added

**1. `setContent` op — the "save as" verb.**
Replaces the entire body in one call. Must be the only op in its batch (rejected at parse time otherwise — its semantics don't compose with snapshot-based line ops). Title re-derives from the new H1 like `/api/upload` does, so a fresh body doesn't keep an unrelated old title. Records an `agent` revision.

**2. `to: -1` sentinel on `deleteLineRange` / `replaceLineRange`.**
Means "through end of document." Removes the fetch round-trip for tail edits and avoids the off-by-one that hits any client computing line count via `split("\n").length` on content with a trailing newline.

**3. `lineCount` on `GET /api/agent/docs/[slug]`.**
The canonical visible-line count the server uses to validate line-addressed ops. Surfaced so agents stop having to compute it themselves (and stop being wrong about trailing newlines). Backed by `visibleLineCount` from the applier — same source of truth, no risk of divergence.

## Why these three together

The agent's full-doc sync took three calls (fetch → failed `replaceLineRange 1..177` → corrected `1..176`) where one should have sufficed. With these in place, the same workflow becomes:

```
POST /api/agent/docs/<slug>/edits
ops: [{ type: "setContent", content: <body> }]
```

One call. No fetch. Atomic. Recorded as agent revision.

## Tests

21 new tests across schema, applier, and routes. Suite: 269/269 green. Typecheck + lint clean.

## Smoke verification

Live dev-server smoke covered: `setContent` whole-doc replace + revision recorded, post-replace `lineCount` reflects new doc, `replaceLineRange to: -1` working as described, mixed-batch (setContent + other op) returns 400, title auto-derives from new H1.

## Skill update

`~/.claude/skills/md-upload/SKILL.md` extended with a "Saving the whole body" subsection, the `setContent` row in the op-types table, and a note about `lineCount` on the fetch response (with the trailing-newline caveat called out explicitly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to replace entire document content in a single operation.
  * Added support for end-of-document reference in line range operations.
  * API now returns document line count information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->