### PR TITLE
feat(agent-api): add dryRun mode to edits endpoint

### DIFF
--- a/src/app/api/agent/docs/[slug]/edits/route.test.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.test.ts
@@ -342,3 +342,131 @@ describe("POST /api/agent/docs/[slug]/edits — content size limit", () => {
     expect(res.status).toBe(413);
   });
 });
+
+describe("POST /api/agent/docs/[slug]/edits — dryRun", () => {
+  it("returns the would-be content without writing or recording a revision", async () => {
+    const { token, doc } = await setupAuthorizedDoc("hello foo world\n");
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [{ type: "replace", find: "foo", replace: "bar" }],
+        dryRun: true,
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      doc: { content: string; slug: string };
+      revisionId: string | null;
+      dryRun: boolean;
+    };
+    expect(body.doc.content).toBe("hello bar world\n");
+    expect(body.revisionId).toBeNull();
+    expect(body.dryRun).toBe(true);
+
+    const { getDocBySlug } = await import("@/lib/db");
+    const after = await getDocBySlug(doc.slug);
+    expect(after?.content).toBe("hello foo world\n");
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(0);
+  });
+
+  it("returns the same structured 409 shape for ambiguous matches without recording a revision", async () => {
+    const content = "foo line one\nfoo line two\n";
+    const { token, doc } = await setupAuthorizedDoc(content);
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [{ type: "replace", find: "foo", replace: "bar" }],
+        dryRun: true,
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      error: string;
+      failedAt: number;
+      matchCount: number;
+    };
+    expect(body.error).toBe("ambiguous_match");
+    expect(body.failedAt).toBe(0);
+    expect(body.matchCount).toBe(2);
+
+    const { getDocBySlug } = await import("@/lib/db");
+    const after = await getDocBySlug(doc.slug);
+    expect(after?.content).toBe(content);
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(0);
+  });
+
+  it("returns 409 no_match for missing queries without writing", async () => {
+    const { token, doc } = await setupAuthorizedDoc("hello\n");
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [{ type: "replace", find: "missing", replace: "x" }],
+        dryRun: true,
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("no_match");
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(0);
+  });
+
+  it("rejects dryRun when it is not a boolean", async () => {
+    const { token, doc } = await setupAuthorizedDoc("x\n");
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [{ type: "replace", find: "x", replace: "y" }],
+        dryRun: "yes",
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("still writes normally when dryRun is false", async () => {
+    const { token, doc } = await setupAuthorizedDoc("hello foo world\n");
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [{ type: "replace", find: "foo", replace: "bar" }],
+        dryRun: false,
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      doc: { content: string };
+      revisionId: string | null;
+      dryRun?: boolean;
+    };
+    expect(body.doc.content).toBe("hello bar world\n");
+    expect(body.revisionId).toMatch(/^rv_/);
+    expect(body.dryRun).toBeUndefined();
+  });
+
+  it("returns 413 when the would-be content exceeds 1 MB without writing", async () => {
+    const { token, doc } = await setupAuthorizedDoc("seed\n");
+    const huge = "x".repeat(1024 * 1024 + 10);
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [{ type: "replace", find: "seed", replace: huge }],
+        dryRun: true,
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(413);
+
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(0);
+  });
+});

--- a/src/app/api/agent/docs/[slug]/edits/route.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.ts
@@ -9,7 +9,7 @@ import { apply, type ApplierError } from "@/lib/operation-applier";
 
 const MAX_BYTES = 1024 * 1024;
 
-type Body = { ops?: unknown; summary?: unknown };
+type Body = { ops?: unknown; summary?: unknown; dryRun?: unknown };
 
 function applierErrorBody(
   error: ApplierError,
@@ -88,6 +88,14 @@ export async function POST(
     summary = body.summary;
   }
 
+  let dryRun = false;
+  if (body.dryRun !== undefined) {
+    if (typeof body.dryRun !== "boolean") {
+      return jsonError(400, "dryRun must be a boolean");
+    }
+    dryRun = body.dryRun;
+  }
+
   const owned = await requireOwnedDoc(req, slug);
   if (!owned.ok) return owned.response;
   const { auth, doc } = owned;
@@ -102,6 +110,33 @@ export async function POST(
 
   if (Buffer.byteLength(result.content, "utf8") > MAX_BYTES) {
     return jsonError(413, "Content exceeds 1MB limit");
+  }
+
+  if (dryRun) {
+    // setContent re-derives title from the new H1; mirror that here so the
+    // preview matches what a real call would persist.
+    const isSetContent =
+      parsed.ops.length === 1 && parsed.ops[0]!.type === "setContent";
+    const previewTitle = isSetContent
+      ? resolveTitle(result.content, undefined)
+      : resolveTitle(result.content, doc.title);
+    return new Response(
+      JSON.stringify({
+        doc: {
+          id: doc.id,
+          slug: doc.slug,
+          title: previewTitle,
+          kind: doc.kind,
+          tags: doc.tags,
+          content: result.content,
+          createdAt: doc.createdAt,
+          updatedAt: doc.updatedAt,
+        },
+        revisionId: null,
+        dryRun: true,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
   }
 
   // No-op short-circuit: skip the chokepoint write so a no-op batch doesn't


### PR DESCRIPTION
## Summary

Closes #49.

Adds a top-level `dryRun: true` flag to `POST /api/agent/docs/<slug>/edits`. When set, the route runs `OperationApplier.apply` and the 1 MB size check as normal, then returns a preview of the would-be document without calling `writeDocContent`. No transaction, no revision recorded, no DB mutation.

## Response shape

- Success: same `{doc, revisionId}` shape as a real call, with `revisionId: null` and an explicit `dryRun: true` marker so callers can verify the flag was honored.
- Structured 409 (`no_match`, `ambiguous_match`, `line_out_of_range`, etc.): identical shape to a real call, so agents can use the same error-handling path either way.
- 413 still fires when the would-be content exceeds 1 MB — that's a useful preview signal.

## Notes

- The preview response re-derives title via `resolveTitle` the same way the real path does, so a `setContent` dry run shows the title that would be persisted.
- `dryRun: true` only appears in the response when the flag was set; real writes keep their existing shape.
- Non-boolean `dryRun` returns 400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `dryRun` parameter to document edits endpoint. When enabled, returns updated content preview without persisting changes or recording revisions.

* **Tests**
  * Added comprehensive test coverage for dry-run mode, including parameter validation, content size limit enforcement, and revision handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->