### PR TITLE
feat(agent-api): add If-Match optimistic concurrency

### DIFF
--- a/migrations/009_add_current_revision_id.sql
+++ b/migrations/009_add_current_revision_id.sql
@@ -1,0 +1,11 @@
+-- 009_add_current_revision_id.sql
+-- Optimistic concurrency for the agent edits API (issue #51). The column
+-- caches the latest doc_revisions.external_id for cheap If-Match comparison.
+-- Writes populate it inside the same transaction that records the revision,
+-- so the cache and the revision log can never diverge.
+--
+-- NULL means "no revisions yet" (the doc has not been edited since creation).
+-- Existing rows pre-dating this migration also start as NULL. The first
+-- write under the new code populates it.
+
+ALTER TABLE docs ADD COLUMN current_revision_id text;

--- a/src/app/api/agent/docs/[slug]/edits/route.test.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.test.ts
@@ -43,8 +43,16 @@ async function setupAuthorizedDoc(content: string) {
   return { token, doc };
 }
 
-function postReq(slug: string, body: unknown, token: string | null) {
-  const headers: Record<string, string> = { "content-type": "application/json" };
+function postReq(
+  slug: string,
+  body: unknown,
+  token: string | null,
+  extraHeaders: Record<string, string> = {},
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...extraHeaders,
+  };
   if (token) headers.authorization = `Bearer ${token}`;
   const req = new NextRequest(
     `http://localhost/api/agent/docs/${slug}/edits`,
@@ -468,5 +476,171 @@ describe("POST /api/agent/docs/[slug]/edits — dryRun", () => {
 
     const listed = await RevisionLog.list(doc.id);
     expect(listed.revisions).toHaveLength(0);
+  });
+});
+
+describe("POST /api/agent/docs/[slug]/edits — If-Match", () => {
+  it("succeeds when If-Match matches the doc's current revisionId", async () => {
+    const { token, doc } = await setupAuthorizedDoc("hello foo\n");
+    // First write to populate current_revision_id.
+    const first = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+      token.plaintext,
+    );
+    const firstBody = (await first.json()) as { revisionId: string };
+
+    const second = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "bar", replace: "baz" }] },
+      token.plaintext,
+      { "if-match": firstBody.revisionId },
+    );
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as {
+      doc: { content: string };
+      revisionId: string;
+    };
+    expect(secondBody.doc.content).toBe("hello baz\n");
+    expect(secondBody.revisionId).not.toBe(firstBody.revisionId);
+  });
+
+  it("returns 412 with currentRevisionId when If-Match is stale", async () => {
+    const { token, doc } = await setupAuthorizedDoc("hello foo\n");
+    const first = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+      token.plaintext,
+    );
+    const firstBody = (await first.json()) as { revisionId: string };
+
+    // Land an unrelated edit so the current revision id moves on.
+    const second = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "bar", replace: "baz" }] },
+      token.plaintext,
+    );
+    const secondBody = (await second.json()) as { revisionId: string };
+
+    // Try to apply with the stale token from the first write.
+    const stale = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "baz", replace: "qux" }] },
+      token.plaintext,
+      { "if-match": firstBody.revisionId },
+    );
+    expect(stale.status).toBe(412);
+    const staleBody = (await stale.json()) as {
+      error: string;
+      currentRevisionId: string;
+    };
+    expect(staleBody.error).toBe("revision_mismatch");
+    expect(staleBody.currentRevisionId).toBe(secondBody.revisionId);
+
+    // No stray write was recorded for the stale attempt.
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(2);
+  });
+
+  it("returns 412 when If-Match is sent but the doc has no revisions yet", async () => {
+    const { token, doc } = await setupAuthorizedDoc("seed\n");
+    const res = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "seed", replace: "x" }] },
+      token.plaintext,
+      { "if-match": "rv_anything" },
+    );
+    expect(res.status).toBe(412);
+    const body = (await res.json()) as {
+      error: string;
+      currentRevisionId: string | null;
+    };
+    expect(body.error).toBe("revision_mismatch");
+    expect(body.currentRevisionId).toBeNull();
+  });
+
+  it("rejects an empty If-Match header with 400", async () => {
+    const { token, doc } = await setupAuthorizedDoc("seed\n");
+    const res = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "seed", replace: "x" }] },
+      token.plaintext,
+      { "if-match": "" },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("ignores If-Match when not sent (no regression for non-opting agents)", async () => {
+    const { token, doc } = await setupAuthorizedDoc("seed\n");
+    // Two sequential writes without If-Match — both should land.
+    const first = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "seed", replace: "one" }] },
+      token.plaintext,
+    );
+    expect(first.status).toBe(200);
+    const second = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "one", replace: "two" }] },
+      token.plaintext,
+    );
+    expect(second.status).toBe(200);
+    const body = (await second.json()) as { doc: { content: string } };
+    expect(body.doc.content).toBe("two\n");
+  });
+
+  it("dryRun + stale If-Match returns 412 with no write", async () => {
+    const { token, doc } = await setupAuthorizedDoc("hello foo\n");
+    await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+      token.plaintext,
+    );
+
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [{ type: "replace", find: "bar", replace: "baz" }],
+        dryRun: true,
+      },
+      token.plaintext,
+      { "if-match": "rv_stale" },
+    );
+    expect(res.status).toBe(412);
+    const listed = await RevisionLog.list(doc.id);
+    expect(listed.revisions).toHaveLength(1);
+  });
+
+  it("dryRun + matching If-Match returns the preview without bumping the revision", async () => {
+    const { token, doc } = await setupAuthorizedDoc("hello foo\n");
+    const first = await postReq(
+      doc.slug,
+      { ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+      token.plaintext,
+    );
+    const firstBody = (await first.json()) as { revisionId: string };
+
+    const res = await postReq(
+      doc.slug,
+      {
+        ops: [{ type: "replace", find: "bar", replace: "baz" }],
+        dryRun: true,
+      },
+      token.plaintext,
+      { "if-match": firstBody.revisionId },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      doc: { content: string };
+      revisionId: string | null;
+      dryRun: boolean;
+    };
+    expect(body.doc.content).toBe("hello baz\n");
+    expect(body.revisionId).toBeNull();
+    expect(body.dryRun).toBe(true);
+
+    const listed = await RevisionLog.list(doc.id);
+    // Only the first write recorded a revision; the dryRun did not.
+    expect(listed.revisions).toHaveLength(1);
   });
 });

--- a/src/app/api/agent/docs/[slug]/edits/route.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.ts
@@ -96,9 +96,32 @@ export async function POST(
     dryRun = body.dryRun;
   }
 
+  // Optimistic concurrency: agents that opt in pass the revisionId they
+  // last read in If-Match. We re-check under FOR UPDATE inside writeDocContent
+  // to close the race between this read and the write, but an early check
+  // here short-circuits dryRun and saves work in the common stale case.
+  const ifMatchHeader = req.headers.get("if-match");
+  const expectedRevisionId = ifMatchHeader?.trim() || null;
+  if (ifMatchHeader !== null && expectedRevisionId === null) {
+    return jsonError(400, "If-Match header must not be empty");
+  }
+
   const owned = await requireOwnedDoc(req, slug);
   if (!owned.ok) return owned.response;
   const { auth, doc } = owned;
+
+  if (
+    expectedRevisionId !== null &&
+    doc.currentRevisionId !== expectedRevisionId
+  ) {
+    return new Response(
+      JSON.stringify({
+        error: "revision_mismatch",
+        currentRevisionId: doc.currentRevisionId,
+      }),
+      { status: 412, headers: { "content-type": "application/json" } },
+    );
+  }
 
   const result = apply(doc.content, parsed.ops);
   if (!result.ok) {
@@ -178,7 +201,17 @@ export async function POST(
     summary,
     source: "agent",
     ownerId: auth.ownerId,
+    expectedRevisionId: expectedRevisionId ?? undefined,
   });
+  if (!writeResult.ok) {
+    return new Response(
+      JSON.stringify({
+        error: "revision_mismatch",
+        currentRevisionId: writeResult.currentRevisionId,
+      }),
+      { status: 412, headers: { "content-type": "application/json" } },
+    );
+  }
 
   revalidatePath("/");
   revalidatePath(`/v/${slug}`);

--- a/src/app/api/agent/docs/[slug]/route.test.ts
+++ b/src/app/api/agent/docs/[slug]/route.test.ts
@@ -84,6 +84,33 @@ describe("GET /api/agent/docs/[slug]", () => {
     expect(body.lineCount).toBe(0);
   });
 
+  it("returns revisionId: null for a fresh doc with no revisions", async () => {
+    const { token, doc } = await setupAuthorizedDoc("first\n", "Fresh");
+    const res = await getReq(doc.slug, token.plaintext);
+    const body = (await res.json()) as { revisionId: string | null };
+    expect(body.revisionId).toBeNull();
+  });
+
+  it("returns the latest revision's external_id after an edit", async () => {
+    const { token, doc } = await setupAuthorizedDoc("seed\n", "Edited");
+    // Drive a write through the chokepoint so current_revision_id is set.
+    const { writeDocContent } = await import("@/lib/doc-mutation-path");
+    const write = await writeDocContent({
+      docId: doc.id,
+      newContent: "edited\n",
+      newSearchText: "edited",
+      summary: null,
+      source: "agent",
+      ownerId: TEST_OWNER,
+    });
+    if (!write.ok) throw new Error("setup write failed");
+
+    const res = await getReq(doc.slug, token.plaintext);
+    const body = (await res.json()) as { revisionId: string | null };
+    expect(body.revisionId).toBe(write.revisionId);
+    expect(body.revisionId).toMatch(/^rv_/);
+  });
+
   it("returns 401 without auth", async () => {
     const { doc } = await setupAuthorizedDoc("x\n");
     const res = await getReq(doc.slug, null);

--- a/src/app/api/agent/docs/[slug]/route.ts
+++ b/src/app/api/agent/docs/[slug]/route.ts
@@ -23,6 +23,10 @@ export async function GET(
       // (and don't get bit by trailing-newline off-by-ones when planning
       // line-addressed ops).
       lineCount: visibleLineCount(doc.content),
+      // Optimistic-concurrency token. Echo this back in `If-Match` on the
+      // next edit to ensure no other writer changed the doc in between.
+      // null when the doc has never been edited since creation.
+      revisionId: doc.currentRevisionId,
       createdAt: doc.createdAt,
       updatedAt: doc.updatedAt,
     }),

--- a/src/app/api/docs/[slug]/restore/route.ts
+++ b/src/app/api/docs/[slug]/restore/route.ts
@@ -46,6 +46,13 @@ export async function POST(
     source: "restore",
     ownerId: auth.ownerId,
   });
+  if (!result.ok) {
+    // Restore does not pass expectedRevisionId, so this branch is
+    // unreachable — but the typed union forces an explicit acknowledgement.
+    throw new Error(
+      "writeDocContent returned revision_mismatch without expectedRevisionId",
+    );
+  }
 
   revalidatePath("/");
   revalidatePath(`/v/${slug}`);

--- a/src/app/api/docs/[slug]/route.ts
+++ b/src/app/api/docs/[slug]/route.ts
@@ -151,6 +151,13 @@ export async function PATCH(
       source,
       ownerId: auth.ownerId,
     });
+    if (!result.ok) {
+      // PATCH does not pass expectedRevisionId, so this branch is unreachable
+      // — but the typed union forces an explicit acknowledgement.
+      throw new Error(
+        "writeDocContent returned revision_mismatch without expectedRevisionId",
+      );
+    }
     updated = result.doc;
   } else {
     // Title-only / kind-only / tags-only edits don't snapshot content; keep

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -14,6 +14,12 @@ export type Doc = {
   searchText: string | null;
   createdAt: Date;
   updatedAt: Date;
+  /**
+   * external_id of the most recent doc_revisions row for this doc, or null
+   * if the doc has never been edited since creation. Surfaced on the agent
+   * GET as the If-Match token.
+   */
+  currentRevisionId: string | null;
 };
 
 export type DocSummary = Pick<
@@ -32,6 +38,7 @@ type DocRow = {
   search_text: string | null;
   created_at: Date;
   updated_at: Date;
+  current_revision_id: string | null;
 };
 
 type DocSummaryRow = {
@@ -56,6 +63,7 @@ function rowToDoc(row: DocRow): Doc {
     searchText: row.search_text,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    currentRevisionId: row.current_revision_id,
   };
 }
 
@@ -91,7 +99,7 @@ export async function insertDoc(input: {
   const result = await sql<DocRow>`
     INSERT INTO docs (slug, owner_id, title, content, kind, tags, search_text)
     VALUES (${input.slug}, ${input.ownerId}, ${input.title}, ${input.content}, ${input.kind}, ${toPgTextArray(input.tags ?? [])}, ${input.searchText})
-    RETURNING id, slug, owner_id, title, content, kind, tags, search_text, created_at, updated_at
+    RETURNING id, slug, owner_id, title, content, kind, tags, search_text, created_at, updated_at, current_revision_id
   `;
   const row = result.rows[0];
   if (!row) throw new Error("INSERT returned no rows");
@@ -135,7 +143,7 @@ export async function updateDocBySlug(
     UPDATE docs
     SET ${sets.join(", ")}
     WHERE slug = ${slugParam}
-    RETURNING id, slug, owner_id, title, content, kind, tags, search_text, created_at, updated_at
+    RETURNING id, slug, owner_id, title, content, kind, tags, search_text, created_at, updated_at, current_revision_id
   `;
 
   const result = await sql.query<DocRow>(text, values);
@@ -155,7 +163,7 @@ export async function deleteDocBySlug(
 
 export async function getDocBySlug(slug: string): Promise<Doc | null> {
   const result = await sql<DocRow>`
-    SELECT id, slug, owner_id, title, content, kind, tags, search_text, created_at, updated_at
+    SELECT id, slug, owner_id, title, content, kind, tags, search_text, created_at, updated_at, current_revision_id
     FROM docs
     WHERE slug = ${slug}
     LIMIT 1

--- a/src/lib/doc-mutation-path.test.ts
+++ b/src/lib/doc-mutation-path.test.ts
@@ -19,6 +19,15 @@ async function createTestDoc(content: string): Promise<Doc> {
   });
 }
 
+function expectOk(
+  result: DocMutationPath.WriteDocContentResult,
+): DocMutationPath.WriteDocContentSuccess {
+  if (!result.ok) {
+    throw new Error(`expected ok, got ${result.kind}`);
+  }
+  return result;
+}
+
 beforeAll(() => {
   if (!process.env.POSTGRES_URL) {
     throw new Error(
@@ -34,14 +43,16 @@ afterAll(async () => {
 describe("DocMutationPath.writeDocContent — return shape", () => {
   it("returns the updated doc so callers don't need a second query", async () => {
     const doc = await createTestDoc("v0");
-    const result = await DocMutationPath.writeDocContent({
-      docId: doc.id,
-      newContent: "v1",
-      newTitle: "Renamed",
-      summary: null,
-      source: "manual",
-      ownerId: TEST_OWNER,
-    });
+    const result = expectOk(
+      await DocMutationPath.writeDocContent({
+        docId: doc.id,
+        newContent: "v1",
+        newTitle: "Renamed",
+        summary: null,
+        source: "manual",
+        ownerId: TEST_OWNER,
+      }),
+    );
     expect(result.doc.content).toBe("v1");
     expect(result.doc.title).toBe("Renamed");
     expect(result.doc.id).toBe(doc.id);
@@ -101,13 +112,15 @@ describe("DocMutationPath.writeDocContent", () => {
   it("updates doc content and records a revision capturing the previous content", async () => {
     const doc = await createTestDoc("# Original\n\nbody");
 
-    const result = await DocMutationPath.writeDocContent({
-      docId: doc.id,
-      newContent: "# Updated\n\nbody",
-      summary: "Title rename",
-      source: "manual",
-      ownerId: TEST_OWNER,
-    });
+    const result = expectOk(
+      await DocMutationPath.writeDocContent({
+        docId: doc.id,
+        newContent: "# Updated\n\nbody",
+        summary: "Title rename",
+        source: "manual",
+        ownerId: TEST_OWNER,
+      }),
+    );
 
     // Doc row reflects the new content.
     const persisted = await getDocBySlug(doc.slug);
@@ -123,6 +136,90 @@ describe("DocMutationPath.writeDocContent", () => {
   });
 });
 
+describe("DocMutationPath.writeDocContent — expectedRevisionId", () => {
+  it("succeeds when the expected revisionId matches the doc's current_revision_id", async () => {
+    const doc = await createTestDoc("v0");
+    // First write populates current_revision_id.
+    const first = expectOk(
+      await DocMutationPath.writeDocContent({
+        docId: doc.id,
+        newContent: "v1",
+        summary: null,
+        source: "manual",
+        ownerId: TEST_OWNER,
+      }),
+    );
+
+    const second = expectOk(
+      await DocMutationPath.writeDocContent({
+        docId: doc.id,
+        newContent: "v2",
+        summary: null,
+        source: "manual",
+        ownerId: TEST_OWNER,
+        expectedRevisionId: first.revisionId,
+      }),
+    );
+    expect(second.doc.content).toBe("v2");
+    expect(second.doc.currentRevisionId).toBe(second.revisionId);
+  });
+
+  it("returns revision_mismatch when expectedRevisionId is stale", async () => {
+    const doc = await createTestDoc("v0");
+    const first = expectOk(
+      await DocMutationPath.writeDocContent({
+        docId: doc.id,
+        newContent: "v1",
+        summary: null,
+        source: "manual",
+        ownerId: TEST_OWNER,
+      }),
+    );
+    // Advance current_revision_id past `first` without using expectedRevisionId.
+    expectOk(
+      await DocMutationPath.writeDocContent({
+        docId: doc.id,
+        newContent: "v2",
+        summary: null,
+        source: "manual",
+        ownerId: TEST_OWNER,
+      }),
+    );
+
+    const stale = await DocMutationPath.writeDocContent({
+      docId: doc.id,
+      newContent: "v3",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+      expectedRevisionId: first.revisionId,
+    });
+    expect(stale.ok).toBe(false);
+    if (stale.ok) throw new Error("unreachable");
+    expect(stale.kind).toBe("revision_mismatch");
+    expect(stale.currentRevisionId).not.toBe(first.revisionId);
+
+    // Doc content was not advanced by the stale attempt.
+    const persisted = await getDocBySlug(doc.slug);
+    expect(persisted?.content).toBe("v2");
+  });
+
+  it("returns revision_mismatch when expectedRevisionId is set but the doc has no revisions yet", async () => {
+    const doc = await createTestDoc("v0");
+    const result = await DocMutationPath.writeDocContent({
+      docId: doc.id,
+      newContent: "v1",
+      summary: null,
+      source: "manual",
+      ownerId: TEST_OWNER,
+      expectedRevisionId: "rv_anything",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.currentRevisionId).toBeNull();
+  });
+});
+
 describe("DocMutationPath.writeDocContent — concurrent writers", () => {
   it("serializes via FOR UPDATE so each revision snapshots the immediate prior state", async () => {
     // Two writers race against the same doc. With row-level locking, the
@@ -133,7 +230,7 @@ describe("DocMutationPath.writeDocContent — concurrent writers", () => {
     // matches whichever writer committed second.
     const doc = await createTestDoc("v0");
 
-    const [resultA, resultB] = await Promise.all([
+    const [rawA, rawB] = await Promise.all([
       DocMutationPath.writeDocContent({
         docId: doc.id,
         newContent: "vA",
@@ -149,6 +246,8 @@ describe("DocMutationPath.writeDocContent — concurrent writers", () => {
         ownerId: TEST_OWNER,
       }),
     ]);
+    const resultA = expectOk(rawA);
+    const resultB = expectOk(rawB);
 
     // The persisted content matches whichever writer committed last.
     const persisted = await getDocBySlug(doc.slug);

--- a/src/lib/doc-mutation-path.ts
+++ b/src/lib/doc-mutation-path.ts
@@ -13,12 +13,34 @@ export type WriteDocContentInput = {
   summary: string | null;
   source: RevisionLog.RevisionSource;
   ownerId: string;
+  /**
+   * Optional optimistic-concurrency token. When provided, the write only
+   * proceeds if `docs.current_revision_id` (read under FOR UPDATE) equals
+   * this value. Mismatch returns {ok:false, kind:"revision_mismatch", ...}
+   * so the caller can surface 412 without bubbling exceptions.
+   *
+   * For a doc that has never been edited (current_revision_id IS NULL) the
+   * caller should omit this field — there is no token to compare against.
+   * Concurrency protection becomes available on the first edit.
+   */
+  expectedRevisionId?: string;
 };
 
-export type WriteDocContentResult = {
+export type WriteDocContentSuccess = {
+  ok: true;
   doc: Doc;
   revisionId: string;
 };
+
+export type WriteDocContentMismatch = {
+  ok: false;
+  kind: "revision_mismatch";
+  currentRevisionId: string | null;
+};
+
+export type WriteDocContentResult =
+  | WriteDocContentSuccess
+  | WriteDocContentMismatch;
 
 type DocRow = {
   id: string;
@@ -31,6 +53,7 @@ type DocRow = {
   search_text: string | null;
   created_at: Date;
   updated_at: Date;
+  current_revision_id: string | null;
 };
 
 function rowToDoc(row: DocRow): Doc {
@@ -45,9 +68,9 @@ function rowToDoc(row: DocRow): Doc {
     searchText: row.search_text,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    currentRevisionId: row.current_revision_id,
   };
 }
-
 
 export async function writeDocContent(
   input: WriteDocContentInput,
@@ -60,14 +83,34 @@ export async function writeDocContent(
     // UPDATE, both writers can read the same prevContent and the second
     // revision would snapshot stale content instead of the actual immediate
     // prior state.
-    const prevResult = await client.query<{ content: string }>(
-      `SELECT content FROM docs WHERE id = $1 FOR UPDATE`,
+    const prevResult = await client.query<{
+      content: string;
+      current_revision_id: string | null;
+    }>(
+      `SELECT content, current_revision_id FROM docs WHERE id = $1 FOR UPDATE`,
       [input.docId],
     );
     const prev = prevResult.rows[0];
     if (!prev) {
       throw new Error(`docs row not found for id=${input.docId}`);
     }
+
+    if (
+      input.expectedRevisionId !== undefined &&
+      prev.current_revision_id !== input.expectedRevisionId
+    ) {
+      await client.query("ROLLBACK");
+      return {
+        ok: false,
+        kind: "revision_mismatch",
+        currentRevisionId: prev.current_revision_id,
+      };
+    }
+
+    // Pre-generate the new revision external_id so the docs UPDATE and the
+    // doc_revisions INSERT can both reference it within this transaction —
+    // keeping the cache (current_revision_id) and the canonical row in sync.
+    const newRevisionExternalId = RevisionLog.generateExternalId();
 
     const sets: string[] = ["content = $1"];
     const values: unknown[] = [input.newContent];
@@ -87,12 +130,13 @@ export async function writeDocContent(
     if (input.newTags !== undefined) {
       sets.push(`tags = ${bind(toPgTextArray(input.newTags))}`);
     }
+    sets.push(`current_revision_id = ${bind(newRevisionExternalId)}`);
     sets.push(`updated_at = now()`);
     const docIdParam = bind(input.docId);
     const updateResult = await client.query<DocRow>(
       `UPDATE docs SET ${sets.join(", ")} WHERE id = ${docIdParam}
        RETURNING id, slug, owner_id, title, content, kind, tags, search_text,
-                 created_at, updated_at`,
+                 created_at, updated_at, current_revision_id`,
       values,
     );
     const updatedRow = updateResult.rows[0];
@@ -108,12 +152,17 @@ export async function writeDocContent(
         summary: input.summary,
         source: input.source,
         ownerId: input.ownerId,
+        externalId: newRevisionExternalId,
       },
       client,
     );
 
     await client.query("COMMIT");
-    return { doc: rowToDoc(updatedRow), revisionId: revision.externalId };
+    return {
+      ok: true,
+      doc: rowToDoc(updatedRow),
+      revisionId: revision.externalId,
+    };
   } catch (err) {
     await client.query("ROLLBACK");
     throw err;

--- a/src/lib/revision-log.ts
+++ b/src/lib/revision-log.ts
@@ -33,6 +33,13 @@ export type RecordInput = {
   summary: string | null;
   source: RevisionSource;
   ownerId: string;
+  /**
+   * Optional pre-generated external_id. Lets callers (e.g. writeDocContent)
+   * weave the same value into related writes in the same transaction so
+   * `docs.current_revision_id` and `doc_revisions.external_id` are populated
+   * in lockstep without a second round trip.
+   */
+  externalId?: string;
 };
 
 export type RecordResult = {
@@ -40,11 +47,15 @@ export type RecordResult = {
   createdAt: Date;
 };
 
+export function generateExternalId(): string {
+  return `rv_${generateId()}`;
+}
+
 export async function record(
   input: RecordInput,
   runner: Runner = sql,
 ): Promise<RecordResult> {
-  const externalId = `rv_${generateId()}`;
+  const externalId = input.externalId ?? generateExternalId();
   const { bytesAdded, bytesRemoved } = computeDiff(
     input.prevContent,
     input.nextContent,


### PR DESCRIPTION
Closes #51.

## Summary

Agents can now opt into "apply only if the doc hasn't changed since I read it." `GET /api/agent/docs/<slug>` returns `revisionId` (the current latest `doc_revisions.external_id`, or null for fresh docs). The agent echoes that token back as `If-Match: <revisionId>` on the next edit. Mismatch returns 412 with the current revision id so the agent can re-fetch and replan.

## Single source of truth

The "version" of a doc state is **the latest revision's `external_id`** — the same `rv_xxx` token returned by every successful write. No parallel int counter. Migration 009 adds `current_revision_id text` to docs as a cache of that pointer; `writeDocContent` populates it in the same transaction that records the revision so the cache and the canonical row can never diverge.

## Wire contract

- `GET /api/agent/docs/<slug>` → response gains `revisionId: string | null`.
- `POST /api/agent/docs/<slug>/edits`:
  - `If-Match` absent → behaves as today (no regression).
  - `If-Match: <revisionId>` matches → write proceeds, response includes the new `revisionId`.
  - `If-Match: <revisionId>` stale → 412 `{ error: "revision_mismatch", currentRevisionId }`.
  - `If-Match: ""` → 400.
  - dryRun honors If-Match the same way (412 short-circuits before any preview work).

## Implementation notes

- Concurrency check happens twice: an early unlocked check at the route boundary (so dryRun and the common stale-then-bail path don't pay for `apply()` work), and a locked re-check inside `writeDocContent`'s existing FOR UPDATE transaction (closes the read-vs-write race).
- `writeDocContent` now returns a discriminated union (`{ok:true, ...} | {ok:false, kind:"revision_mismatch", currentRevisionId}`). PATCH and restore (which never pass `expectedRevisionId`) get a one-line unreachable guard.
- `RevisionLog.record` accepts an optional pre-generated `externalId` so the docs UPDATE and the revisions INSERT can both reference it within one transaction.

## Migration

`migrations/009_add_current_revision_id.sql`. Pure additive: `ALTER TABLE docs ADD COLUMN current_revision_id text` (nullable). Existing rows start NULL — first write under the new code populates them. Already applied to the shared local-and-prod DB.
