### PR TITLE
feat(skill): move md-niftymonkey skill into repo with Phase 2 verbs and CI sync

### DIFF
--- a/.claude/skills/md-niftymonkey/SKILL.md
+++ b/.claude/skills/md-niftymonkey/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: md-niftymonkey
+description: Work with markdown on md.niftymonkey.dev — upload, fetch, edit, list, and delete. Use when the user asks to upload, share, or publish markdown to md.niftymonkey.dev, fetch a doc back, make targeted edits to an existing doc, replace a section by heading, preview an edit before committing, save a fresh full-doc version, or coordinate edits with optimistic concurrency. Triggers on phrases like "upload this to md.niftymonkey", "share this as a markdown link", "put this on md", "fix the typo on my md doc", "update the md doc at <slug>", "rewrite the API section on <slug>", "preview this edit on md", or pointing at a `.md` file with intent to share or modify on this service. Handles atomic find/replace, line-addressed edits, heading-addressed section replacement, dry-run validation, If-Match optimistic concurrency, and structured retry errors.
+---
+
+# md-niftymonkey
+
+Upload, fetch, edit, list, and delete markdown documents on **md.niftymonkey.dev**. Public viewer URLs render with full GitHub-flavored markdown, syntax highlighting, and mermaid diagrams.
+
+> **API era:** Phase 2 of the AI-First API (verbs: `replace`, `insertAfterLine`, `insertBeforeLine`, `deleteLineRange`, `replaceLineRange`, `setContent`, `replaceSection`; flags: `dryRun`; headers: `If-Match`). If a request returns a shape this skill doesn't recognize, the API may have moved on — re-pull the skill from the repo or hosted slug.
+
+## Authentication
+
+Every API call needs `Authorization: Bearer <key>`. The key is a personal API token — create one at https://md.niftymonkey.dev/settings while signed in. Tokens start with `mdk_` and are shown once at creation time; the server stores only a hash, so a lost token has to be revoked and replaced rather than recovered.
+
+Set the token in the shell environment as `MD_API_KEY` before invoking the API. If a request returns 401, the token has been revoked or was never valid — generate a new one at /settings.
+
+## Upload
+
+```bash
+curl -sS -X POST https://md.niftymonkey.dev/api/upload \
+  -H "Content-Type: text/markdown" \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -H "Accept: text/plain" \
+  --data-binary @<path-to-md-file>
+```
+
+`Accept: text/plain` returns just the URL on stdout — pipe-friendly. Drop it for full JSON `{slug, viewUrl, id, title, createdAt}`.
+
+For inline content the agent generated in the conversation, write it to a temp file first to sidestep quoting and special-character pitfalls in shell, upload that file, then delete it.
+
+### Title
+
+Title resolves: explicit override → first `# H1` in content → `"Untitled"`. Default to letting the API auto-extract from the H1 — that's the right move almost every time. Make sure the markdown opens with a meaningful `# Title` line.
+
+When overriding, **always use the JSON path**, never the `X-Title` header. HTTP headers don't reliably carry non-ASCII, so em-dashes, smart quotes, accents, and emoji come back garbled when sent that way. JSON request bodies are parsed as UTF-8 end-to-end.
+
+```bash
+JSON=$(jq -nc --rawfile c <path-to-md-file> --arg t "Title with — em-dashes" '{title: $t, content: $c}')
+curl -sS -X POST https://md.niftymonkey.dev/api/upload \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -H "Accept: text/plain" \
+  -d "$JSON"
+```
+
+### Kind (optional)
+
+`kind` is a free-form tag for grouping docs (e.g. `note`, `essay`, `recipe`). The server normalizes: trim, lowercase, max 64 chars. Send via the JSON `kind` field, or via the `X-Kind` header for raw uploads (ASCII-only — unlike titles, identifiers don't need UTF-8).
+
+```bash
+# JSON
+JSON=$(jq -nc --rawfile c <path-to-md-file> --arg k "essay" '{kind: $k, content: $c}')
+
+# Raw header form
+curl -sS -X POST https://md.niftymonkey.dev/api/upload \
+  -H "Content-Type: text/markdown" \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -H "X-Kind: essay" \
+  --data-binary @<path-to-md-file>
+```
+
+### Limits
+
+- 1 MB max content size — 413 if exceeded.
+- Empty / whitespace-only content — 400.
+- `kind` over 64 characters — 400.
+
+## Fetch
+
+Read a doc back. The public raw endpoint requires no auth.
+
+```bash
+# Markdown body
+curl -sS https://md.niftymonkey.dev/api/raw/<slug>
+
+# JSON: { slug, title, kind, content, createdAt, updatedAt }
+curl -sS -H "Accept: application/json" https://md.niftymonkey.dev/api/raw/<slug>
+```
+
+For agent-context fetches that need line-count metadata for planning line-addressed edits, use the agent endpoint (auth required):
+
+```bash
+curl -sS https://md.niftymonkey.dev/api/agent/docs/<slug> \
+  -H "Authorization: Bearer $MD_API_KEY"
+```
+
+Response: `{id, slug, title, kind, content, lineCount, revisionId, createdAt, updatedAt}`.
+
+- `lineCount` is the canonical visible-line count the server uses to validate line-addressed ops — use it directly rather than computing your own. A `split("\n").length` on content with a trailing newline will be off by one, every time.
+- `revisionId` is the optimistic-concurrency token. Echo it back in the `If-Match` header on the next edit to detect intervening writes (see "Optimistic concurrency" below). `null` for fresh docs that have never been edited.
+
+## Edit — full replace (PATCH)
+
+Update an existing doc in place. Slug stays stable. Send any subset of `content`, `title`, `kind`. At least one field is required.
+
+```bash
+# Replace content (title preserved unless also sent)
+JSON=$(jq -nc --rawfile c <path-to-md-file> '{content: $c}')
+curl -sS -X PATCH https://md.niftymonkey.dev/api/docs/<slug> \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -d "$JSON"
+
+# Set or clear title
+curl -sS -X PATCH https://md.niftymonkey.dev/api/docs/<slug> \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -d '{"title": "New title"}'   # or '{"title": null}' to re-derive from H1
+
+# Set or clear kind
+curl -sS -X PATCH https://md.niftymonkey.dev/api/docs/<slug> \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -d '{"kind": "essay"}'   # or '{"kind": null}' to clear
+```
+
+Returns 200 with `{id, slug, title, kind, content, createdAt, updatedAt}`. 404 unknown slug, 400 empty body / invalid field, 413 over 1 MB.
+
+**Title rederivation rule:** PATCH only changes what you send. To re-derive title from a new H1, send `{"title": null}` (optionally alongside `content`).
+
+PATCH writes record a `cli`-source revision in the doc's history. For agent-attributed history, use the targeted edits API below.
+
+## Edit — targeted (agent ops API)
+
+Use this for changing *part* of a doc — fix a typo, swap a paragraph, append a section, replace a code fence, rewrite the "API" section by name — without rewriting the rest. PATCH replaces the entire body; this API is shaped like an `Edit` tool: find/replace, line-addressed inserts/deletes, and heading-addressed section replacement, atomic across a batch, with structured errors that name exactly why a query failed and where. Successful edits create an `agent`-source revision, viewable at `https://md.niftymonkey.dev/edit/<slug>/revisions`.
+
+### Fetch first
+
+Pull current state with the agent endpoint above so line numbers and find strings anchor against what's really there. Use the returned `lineCount` when planning line-addressed ops, and `revisionId` when you want optimistic concurrency.
+
+### Apply ops
+
+```bash
+curl -sS -X POST https://md.niftymonkey.dev/api/agent/docs/<slug>/edits \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ops": [
+      {"type": "replace", "find": "old phrase", "replace": "new phrase"}
+    ],
+    "summary": "fix typo"
+  }'
+```
+
+Returns `{doc, revisionId}` on success. Body shape: `{ops: [...], summary?: string|null, dryRun?: boolean}`. `summary` is shown in the revision history UI; keep it short and specific. `dryRun: true` validates without writing (see "Preview only" below).
+
+### Op types
+
+| Type | Required fields | Notes |
+|---|---|---|
+| `replace` | `find`, `replace` | String match. Default requires uniqueness — pass `replaceAll: true` to hit every occurrence. `find` must be non-empty. |
+| `insertAfterLine` | `line`, `content` | Inserts `content` plus newline after the 1-indexed line. `line: 0` means "before line 1" (top of file). |
+| `insertBeforeLine` | `line`, `content` | Inserts before the 1-indexed line. Minimum `line: 1`. |
+| `deleteLineRange` | `from`, `to` | Inclusive 1-indexed range. `to: -1` means "through end of doc". |
+| `replaceLineRange` | `from`, `to`, `content` | Replaces the inclusive range with `content` (newline auto-appended). Empty `content` collapses to delete. `to: -1` means "through end of doc". |
+| `setContent` | `content` | Replaces the entire body. Must be the only op in its batch. The "save as" verb — use this for full-doc rewrites that should record an `agent` revision. Title re-derives from the new H1, like upload. |
+| `replaceSection` | `headingPath`, `content` | Replaces a section addressed by heading nesting. `headingPath` is top-down trace of heading texts (e.g. `["API", "Errors"]` matches the H_n "Errors" nested directly under H_(n-1) "API"). The replaced span runs from the matched heading line through the line before the next sibling-or-higher heading. `content` typically includes a heading line. |
+
+### Saving the whole body
+
+When the agent has a freshly-generated full document and wants to push it (recording an `agent` revision rather than the `cli` revision PATCH would record), use `setContent`:
+
+```bash
+JSON=$(jq -nc --rawfile c <path-to-md-file> '{ops:[{type:"setContent", content:$c}], summary:"sync from local file"}')
+curl -sS -X POST https://md.niftymonkey.dev/api/agent/docs/<slug>/edits \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$JSON"
+```
+
+One call. No fetch round-trip. Atomic. Recorded as an agent revision. Don't reach for `replaceLineRange from:1 to:-1` for this — `setContent` is what the verb is named for and reads cleaner in revision history.
+
+### Replacing a section by heading
+
+When the user says "rewrite the Setup section" or "update the API/Errors part", reach for `replaceSection` instead of fetching, counting lines, and computing a `replaceLineRange`. The server walks the markdown tree, finds the heading by name, and resolves the section bounds for you.
+
+```bash
+JSON=$(cat <<'EOF'
+{
+  "ops": [
+    {
+      "type": "replaceSection",
+      "headingPath": ["API", "Errors"],
+      "content": "## Errors\n\nNew errors body. Note that I included the heading line — the replacement covers the heading too."
+    }
+  ],
+  "summary": "rewrite errors section"
+}
+EOF
+)
+curl -sS -X POST https://md.niftymonkey.dev/api/agent/docs/<slug>/edits \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$JSON"
+```
+
+- `headingPath` matches against rendered heading text — inline formatting like `**bold**` is stripped, surrounding whitespace is trimmed, matching is case-sensitive.
+- The replaced span includes the heading line itself. Include a heading line in `content` unless you want to drop the heading entirely.
+- A parent path like `["API"]` covers the parent's whole subtree (children at deeper levels are inside the section).
+- A child path like `["API", "Errors"]` covers only that child's section, ending at the next sibling (or shallower heading, or end of doc).
+- Headings inside fenced code blocks don't count.
+
+If the heading text is duplicated (two `## Errors` under the same parent, or two top-level `# API`), the server returns `ambiguous_heading` with `matchCount`. Add a sibling-or-parent component to disambiguate, or fall back to a line-addressed op.
+
+### Preview only (dryRun)
+
+Pass `dryRun: true` to validate ops and return the would-be content without writing. The doc isn't touched; no revision is recorded. Use this when you want to surface the planned change for human approval before committing, or when building up a complex batch and you want certainty before applying.
+
+```bash
+curl -sS -X POST https://md.niftymonkey.dev/api/agent/docs/<slug>/edits \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ops": [
+      {"type": "replace", "find": "old phrase", "replace": "new phrase"}
+    ],
+    "dryRun": true
+  }'
+```
+
+Successful response includes the same `{doc: {...content: <preview>}}` shape as a real call, plus `revisionId: null` and a `dryRun: true` marker so you can verify the flag was honored. Resolution failures (ambiguous match, line out of range, etc.) return the same structured 409 a real call would. The 1 MB content cap still fires (413) — that's a real preview signal, not a write.
+
+### Optimistic concurrency (If-Match)
+
+When you fetched the doc and want to be certain no other writer changed it before your edit lands, send the `If-Match: <revisionId>` header. The revisionId comes from the GET response (or from a prior successful edit's response). The server compares it under transactional lock, so the check is race-free.
+
+```bash
+# 1. Fetch and capture revisionId
+META=$(curl -sS https://md.niftymonkey.dev/api/agent/docs/<slug> \
+  -H "Authorization: Bearer $MD_API_KEY")
+REV=$(printf '%s' "$META" | jq -r '.revisionId')
+
+# 2. Edit with If-Match
+curl -sS -X POST https://md.niftymonkey.dev/api/agent/docs/<slug>/edits \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "If-Match: $REV" \
+  -d '{"ops":[{"type":"replace","find":"x","replace":"y"}]}'
+```
+
+If the doc has changed since you fetched (or has a non-null `revisionId` and you sent the wrong one), the server returns **412** with `{error: "revision_mismatch", currentRevisionId: "<latest>"}`. Re-fetch (the new GET will include the up-to-date `revisionId`), reconcile your plan against the new content, and retry.
+
+A fresh doc that has never been edited has `revisionId: null` from GET. Concurrency protection requires a non-null token, so for the first edit on a brand-new doc, omit `If-Match`. Subsequent edits can use it normally.
+
+`If-Match` works in `dryRun` too — a stale token short-circuits to 412 before any preview work, so you can use dryRun + If-Match as a "would this still apply cleanly?" probe without committing.
+
+### Resolution rules in batches
+
+- **Line-addressed and heading-addressed ops resolve against the doc as fetched** (the snapshot). Two `deleteLineRange` ops in the same batch reference the original line numbers; a `replaceSection` in the same batch resolves headings against the same snapshot.
+- **String-addressed ops (`replace`) resolve against running content** — they see prior ops in the same batch.
+- Line-addressed and heading-addressed ops in the batch must not target overlapping ranges; that returns `overlapping_line_ops`.
+- `setContent` is exclusive — mixing it with any other op returns 400.
+
+### Structured errors (409)
+
+Any resolution failure aborts the entire batch — the doc is not modified, no revision is recorded.
+
+```json
+{
+  "error": "ambiguous_match",
+  "failedAt": 0,
+  "query": "foo",
+  "matchCount": 4,
+  "matches": [
+    {
+      "line": 47,
+      "column": 1,
+      "previewLines": [
+        {"line": 46, "text": "intro"},
+        {"line": 47, "text": "foo bar"},
+        {"line": 48, "text": "trailing"}
+      ]
+    },
+    {
+      "line": 112,
+      "column": 8,
+      "previewLines": [
+        {"line": 111, "text": "context"},
+        {"line": 112, "text": "before foo end"},
+        {"line": 113, "text": "more"}
+      ]
+    }
+  ]
+}
+```
+
+Each entry in `matches` is one location with its own context window (capped at 5 — `matchCount` always reports the true total). Use the previews to choose a longer `find` string that uniquely targets the match you want.
+
+| `error` | Cause | What to do |
+|---|---|---|
+| `no_match` | `find` string is absent. | Re-fetch — content may have changed, or the query is wrong. |
+| `ambiguous_match` | `find` matched > 1 times without `replaceAll`. | Add surrounding context to `find` until unique, or set `replaceAll: true` if all occurrences should change. |
+| `line_out_of_range` | `line` outside the doc. | Use `lineCount` from the fetch response (or re-fetch). |
+| `range_out_of_range` | `from`/`to` outside the doc. | Re-fetch; consider `to: -1`. |
+| `overlapping_line_ops` | Two line-addressed (or heading-addressed) ops in the batch overlap. | Combine into one `replaceLineRange`/`replaceSection`, or split into two batches. |
+| `heading_not_found` | `headingPath` didn't match any heading. | Re-fetch and check the actual heading text (case, whitespace, surrounding formatting). The full path is echoed back in `headingPath`. |
+| `ambiguous_heading` | `headingPath` matched > 1 heading. | Add a parent or sibling component to disambiguate; the response includes `matchCount`. |
+
+`failedAt` is the index of the failing op in `ops`. Earlier ops have NOT been applied — fix only the failing op and retry.
+
+### Stale-write error (412)
+
+Separate from resolution errors: if you sent `If-Match` and the doc has been modified since, the server returns **412** with `{error: "revision_mismatch", currentRevisionId}`. Re-fetch and retry.
+
+### Limits
+
+- 1 MB cap on the request body and the resulting document.
+- Empty `ops` array — 400.
+- Same auth as upload.
+
+### Shell trap
+
+Pipe responses straight to `jq`, or capture with `RESP=$(curl ...)` then `printf '%s' "$RESP" | jq`. Don't use `echo "$RESP" | jq` in zsh or dash — those shells' `echo` interprets escape sequences in the variable, turning `\n` in the response into real newlines and breaking the JSON. Bash's `echo` is fine, but `printf '%s'` is portable.
+
+## List
+
+```bash
+# 20 most-recent docs (default)
+curl -sS https://md.niftymonkey.dev/api/list \
+  -H "Authorization: Bearer $MD_API_KEY"
+
+# Pagination — pass nextCursor from prior response
+curl -sS "https://md.niftymonkey.dev/api/list?limit=10&cursor=<nextCursor>" \
+  -H "Authorization: Bearer $MD_API_KEY"
+
+# Full-text search (no cursor pagination on search results)
+curl -sS "https://md.niftymonkey.dev/api/list?search=mermaid" \
+  -H "Authorization: Bearer $MD_API_KEY"
+
+# Filter by kind (exact match)
+curl -sS "https://md.niftymonkey.dev/api/list?kind=essay" \
+  -H "Authorization: Bearer $MD_API_KEY"
+```
+
+Response: `{docs: [{id, slug, title, kind, createdAt}, ...], nextCursor: string | null}`. Owner-scoped — only docs uploaded under the calling token's owner are visible. `kind` and `search` can be combined; `kind` works with cursor pagination, `search` does not.
+
+## Delete
+
+```bash
+curl -sS -X DELETE https://md.niftymonkey.dev/api/docs/<slug> \
+  -H "Authorization: Bearer $MD_API_KEY"
+```
+
+Returns 204 on success, 404 if the slug is unknown.
+
+## Output to user
+
+After a successful upload, return the URL plainly so the user can copy it:
+
+```
+Uploaded → https://md.niftymonkey.dev/v/aB3xK9pQ
+```
+
+Don't dump full JSON unless asked. Surface non-2xx errors verbatim so the user sees the exact reason.
+
+## Notes
+
+- `md.niftymonkey.dev` is the canonical host. View URLs (`/v/<slug>`) are public, no auth required — share freely.
+- One personal token from `/settings` covers upload, fetch, edit, delete, and list.
+- Tokens are owner-scoped: list and dashboard views only show docs uploaded under that token's owner.

--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -1,0 +1,61 @@
+# Keeps the hosted copy of the md-niftymonkey skill at
+# https://md.niftymonkey.dev/api/raw/80zOpiWz in sync with the in-repo source
+# at .claude/skills/md-niftymonkey/SKILL.md.
+#
+# Setup (one-time, by the operator who owns the skill doc):
+#   1. Generate a personal API token at https://md.niftymonkey.dev/settings.
+#   2. Save it as the repo secret named MD_API_KEY:
+#        gh secret set MD_API_KEY --body "<token>"
+#      The token must belong to the same WorkOS user that owns slug 80zOpiWz —
+#      otherwise PATCH returns 404.
+#
+# A 200 response from PATCH records a `cli`-source revision in the doc's
+# history, so every CI sync is auditable from /edit/80zOpiWz/revisions.
+
+name: Sync md-niftymonkey skill
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.claude/skills/md-niftymonkey/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-skill
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      SKILL_SLUG: 80zOpiWz
+      SKILL_PATH: .claude/skills/md-niftymonkey/SKILL.md
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: PATCH hosted skill with repo content
+        env:
+          MD_API_KEY: ${{ secrets.MD_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MD_API_KEY:-}" ]; then
+            echo "MD_API_KEY secret is not set. See workflow header for setup."
+            exit 1
+          fi
+          if [ ! -f "$SKILL_PATH" ]; then
+            echo "Expected skill file at $SKILL_PATH but it is missing."
+            exit 1
+          fi
+          BODY=$(jq -nc --rawfile c "$SKILL_PATH" '{content: $c}')
+          curl -sS --fail-with-body -X PATCH \
+            "https://md.niftymonkey.dev/api/docs/$SKILL_SLUG" \
+            -H "Authorization: Bearer $MD_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            -o /tmp/sync-resp.json
+          echo "Synced skill to https://md.niftymonkey.dev/api/raw/$SKILL_SLUG"
+          jq '{slug, title, updatedAt}' /tmp/sync-resp.json

--- a/README.md
+++ b/README.md
@@ -51,3 +51,33 @@ curl -d '{"content":"# hello","title":"My Doc"}' \
 ```
 
 Add `Accept: text/plain` to get just the URL on stdout (pipe-friendly).
+
+## Claude Code skill
+
+Anyone using Claude Code can publish, fetch, and edit markdown on md.niftymonkey.dev through a single skill — no curl recipes required. The skill teaches the full AI-First API: upload, fetch, full-replace PATCH, the targeted ops API (find/replace, line-addressed edits, heading-addressed `replaceSection`, full-doc `setContent`), `dryRun` previews, `If-Match` optimistic concurrency, and the structured 409 / 412 error shapes.
+
+The repo ships the skill at `.claude/skills/md-niftymonkey/SKILL.md`. The same content is published at `https://md.niftymonkey.dev/api/raw/80zOpiWz` and stays in sync via CI on every push to `main` that touches the skill.
+
+### Install (one curl)
+
+Pulls the published version into your Claude Code skills directory:
+
+```bash
+mkdir -p ~/.claude/skills/md-niftymonkey
+curl -sS https://md.niftymonkey.dev/api/raw/80zOpiWz \
+  > ~/.claude/skills/md-niftymonkey/SKILL.md
+```
+
+### Install (from a clone)
+
+If you already have the repo checked out:
+
+```bash
+mkdir -p ~/.claude/skills/md-niftymonkey
+cp .claude/skills/md-niftymonkey/SKILL.md \
+   ~/.claude/skills/md-niftymonkey/
+```
+
+### Token
+
+Both flows need a personal API token from `https://md.niftymonkey.dev/settings`. The skill expects it in `MD_API_KEY` in your shell environment.


### PR DESCRIPTION
Closes #56.

## Summary

Moves the `md-niftymonkey` Claude Code skill into the repo and teaches it the Phase 2 verbs that landed in #49, #51, and #50. Adds a GitHub Action that keeps the hosted copy at `https://md.niftymonkey.dev/api/raw/80zOpiWz` in sync with the in-repo source on every push to `main`.

## What ships

- **`.claude/skills/md-niftymonkey/SKILL.md`** — port of the hosted skill with three new sections plus an API-era callout:
  - `dryRun: true` flag for validate-without-writing (#49).
  - Optimistic concurrency via `If-Match: <revisionId>` + 412 `revision_mismatch` response (#51). GET response gains `revisionId`.
  - `replaceSection` op with `headingPath`, including the new `heading_not_found` and `ambiguous_heading` errors (#50).
  - Frontmatter `description` extended so new triggers ("rewrite the API section on", "preview this edit on md") fire correctly.
- **`.github/workflows/sync-skill.yml`** — triggers on push to `main` when `.claude/skills/md-niftymonkey/**` changes, plus `workflow_dispatch` for manual re-runs. PATCHes `/api/docs/80zOpiWz` with the file content using `MD_API_KEY` from repo secrets. Each sync records a `cli`-source revision, so the history is auditable from `/edit/80zOpiWz/revisions`.
- **`README.md`** — adds a "Claude Code skill" section with both install paths (one-curl from the hosted slug, copy-from-clone for repo users).

## Versioning model

Repo is the source of truth. Hosted version is downstream — published by CI on merge. Drift is structurally impossible because humans don't run the sync. Convenient one-curl install for users; auditable sync trail for maintainers.

## Verification

Repo secret `MD_API_KEY` already set. The workflow's bash step was exercised end-to-end locally against prod (same `jq` + `curl PATCH` flow as the YAML), and the hosted slug now matches the in-repo SKILL.md byte-for-byte (`diff` clean, 361 lines).

The workflow YAML itself can't be dispatched pre-merge — `workflow_dispatch` requires the file on the default branch. The first auto-trigger after merge will close that loop. If YAML syntax misbehaves, a one-line follow-up will fix it; the operational logic is already proven.

## Operator one-time setup (already done)

```
gh secret set MD_API_KEY --repo niftymonkey/md   # token from /settings
```

Token must belong to the WorkOS user that owns slug `80zOpiWz` or PATCH returns 404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Claude Code skill for markdown document management, supporting upload, fetch, edit with targeted operations (find/replace, section replacement), preview, and delete capabilities with concurrency control.

* **Documentation**
  * Updated README with skill installation instructions and comprehensive API documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/md/pull/61)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->