### PR TITLE
fix(mermaid): wait for web fonts before rendering to prevent clipped labels

### DIFF
--- a/src/components/mermaid.tsx
+++ b/src/components/mermaid.tsx
@@ -29,18 +29,28 @@ export function Mermaid({ chart }: { chart: string }) {
 
   useEffect(() => {
     let cancelled = false;
-    loadMermaid()
-      .then((mermaid) => mermaid.render(id, chart))
-      .then(({ svg }) => {
-        if (!cancelled && containerRef.current) {
-          containerRef.current.innerHTML = svg;
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
-        }
-      });
+
+    const renderChart = async () => {
+      const mermaid = await loadMermaid();
+      // Wait for web fonts before rendering: mermaid sizes node boxes by
+      // measuring label text, and a not-yet-loaded font measures too narrow,
+      // which clips labels at the box edge once the real font swaps in.
+      if (typeof document !== "undefined" && document.fonts) {
+        await document.fonts.ready;
+      }
+      if (cancelled) return;
+      const { svg } = await mermaid.render(id, chart);
+      if (!cancelled && containerRef.current) {
+        containerRef.current.innerHTML = svg;
+      }
+    };
+
+    renderChart().catch((err) => {
+      if (!cancelled) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
Mermaid sizes each node box by measuring its rendered label text. The render ran as soon as the mermaid library loaded, before web fonts had finished. With a fallback font's narrower metrics the boxes came out too small, and once the real font swapped in the labels clipped at the box edge.

This awaits `document.fonts.ready` before calling `mermaid.render()`, so text is always measured against the final font.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved diagram rendering with refactored async operations and enhanced cancellation handling to ensure more reliable chart display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/md/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->