### PR TITLE
feat(agent-api): add cross-document edit batch endpoint

### DIFF
--- a/.claude/skills/md-niftymonkey/SKILL.md
+++ b/.claude/skills/md-niftymonkey/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: md-niftymonkey
-description: Work with markdown on md.niftymonkey.dev — upload, fetch, edit, list, and delete. Use when the user asks to upload, share, or publish markdown to md.niftymonkey.dev, fetch a doc back, make targeted edits to an existing doc, replace a section by heading, preview an edit before committing, save a fresh full-doc version, or coordinate edits with optimistic concurrency. Triggers on phrases like "upload this to md.niftymonkey", "share this as a markdown link", "put this on md", "fix the typo on my md doc", "update the md doc at <slug>", "rewrite the API section on <slug>", "preview this edit on md", or pointing at a `.md` file with intent to share or modify on this service. Handles atomic find/replace, line-addressed edits, heading-addressed section replacement, dry-run validation, If-Match optimistic concurrency, and structured retry errors.
+description: Work with markdown on md.niftymonkey.dev: upload, fetch, edit, list, and delete. Use when the user asks to upload, share, or publish markdown to md.niftymonkey.dev, fetch a doc back, make targeted edits to an existing doc, replace a section by heading, preview an edit before committing, save a fresh full-doc version, coordinate edits with optimistic concurrency, or apply one set of edits across many docs at once. Triggers on phrases like "upload this to md.niftymonkey", "share this as a markdown link", "put this on md", "fix the typo on my md doc", "update the md doc at <slug>", "rewrite the API section on <slug>", "preview this edit on md", "rename a term across all my md docs", or pointing at a `.md` file with intent to share or modify on this service. Handles atomic find/replace, line-addressed edits, heading-addressed section replacement, dry-run validation, If-Match optimistic concurrency, cross-document batch edits, and structured retry errors.
 ---
 
 # md-niftymonkey
@@ -312,6 +312,49 @@ Separate from resolution errors: if you sent `If-Match` and the doc has been mod
 ### Shell trap
 
 Pipe responses straight to `jq`, or capture with `RESP=$(curl ...)` then `printf '%s' "$RESP" | jq`. Don't use `echo "$RESP" | jq` in zsh or dash — those shells' `echo` interprets escape sequences in the variable, turning `\n` in the response into real newlines and breaking the JSON. Bash's `echo` is fine, but `printf '%s'` is portable.
+
+## Cross-document edits
+
+`POST /api/agent/edits` applies edits to several docs in one call. Reach for it on fan-out tasks: rename a term everywhere it appears, append a footer to every doc of a kind, fix one typo across a set.
+
+```bash
+curl -sS -X POST https://md.niftymonkey.dev/api/agent/edits \
+  -H "Authorization: Bearer $MD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operations": [
+      {"slug": "aB3xK9pQ", "ops": [{"type": "replace", "find": "old term", "replace": "new term", "replaceAll": true}]},
+      {"slug": "zT7mN2wL", "ops": [{"type": "replace", "find": "old term", "replace": "new term", "replaceAll": true}]}
+    ],
+    "summary": "rename old term to new term"
+  }'
+```
+
+Body shape: `{operations: [{slug, ops}], summary?: string|null, dryRun?: boolean}`. Each entry's `ops` follows the same rules as the single-doc API (every op type, snapshot-vs-running resolution, setContent exclusivity). A slug may appear at most once per request. `summary` is recorded on every written doc's revision. `dryRun: true` previews every doc without writing any.
+
+**Per-document atomic, batch best-effort.** Each doc's ops all land in one revision or none do. A failure on one doc does not roll back or block the others, so the request returns **200** with a per-doc `results` array rather than one overall status:
+
+```json
+{
+  "results": [
+    {"slug": "aB3xK9pQ", "status": "ok", "doc": {"slug": "aB3xK9pQ", "content": "..."}, "revisionId": "rv_..."},
+    {"slug": "zT7mN2wL", "status": "error", "error": "no_match", "failedAt": 0, "query": "old term"}
+  ]
+}
+```
+
+A 200 does not mean every doc changed. Inspect every entry:
+
+| `status` | Fields | Meaning |
+|---|---|---|
+| `ok` | `doc`, `revisionId` | Written. `revisionId` is `null` for a dryRun preview, or for a no-op batch whose ops resolved to identical content (no revision recorded). |
+| `error` | `error` plus matching detail fields | This doc was left untouched. See the values below. |
+
+Per-doc `error` values: `not_found` (slug unknown or owned by someone else), `content_too_large` (the result would exceed 1 MB), and every resolution error from the single-doc 409 table (`no_match`, `ambiguous_match`, `line_out_of_range`, `range_out_of_range`, `overlapping_line_ops`, `heading_not_found`, `ambiguous_heading`) carrying the same `failedAt` and detail fields.
+
+Request-level problems fail the whole call before any doc is touched: malformed JSON, a missing or empty `operations` array, a malformed op (400, naming the offending `operations[i]`), a duplicate slug (400), more than 50 docs (400), or a declared body over 4 MB (413). 401 if unauthenticated.
+
+`If-Match` optimistic concurrency is single-doc only. The batch endpoint does not accept it; when a write must be guarded against an intervening change, edit that doc through `POST /api/agent/docs/<slug>/edits` with `If-Match`.
 
 ## List
 

--- a/src/app/api/agent/docs/[slug]/edits/route.ts
+++ b/src/app/api/agent/docs/[slug]/edits/route.ts
@@ -3,65 +3,17 @@ import { revalidatePath } from "next/cache";
 import { writeDocContent } from "@/lib/doc-mutation-path";
 import { resolveTitle } from "@/lib/title";
 import { stripMarkdown } from "@/lib/strip-md";
-import { jsonError, requireOwnedDoc } from "@/lib/route-helpers";
+import {
+  applierErrorBody,
+  jsonError,
+  requireOwnedDoc,
+} from "@/lib/route-helpers";
 import { parseEditOps } from "@/lib/edit-op-schema";
-import { apply, type ApplierError } from "@/lib/operation-applier";
+import { apply } from "@/lib/operation-applier";
 
 const MAX_BYTES = 1024 * 1024;
 
 type Body = { ops?: unknown; summary?: unknown; dryRun?: unknown };
-
-function applierErrorBody(
-  error: ApplierError,
-  failedAt: number,
-): Record<string, unknown> {
-  switch (error.kind) {
-    case "no_match":
-      return { error: "no_match", failedAt, query: error.query };
-    case "ambiguous_match":
-      return {
-        error: "ambiguous_match",
-        failedAt,
-        query: error.query,
-        matchCount: error.matchCount,
-        matches: error.matches,
-      };
-    case "line_out_of_range":
-      return {
-        error: "line_out_of_range",
-        failedAt,
-        line: error.line,
-        documentLines: error.documentLines,
-      };
-    case "range_out_of_range":
-      return {
-        error: "range_out_of_range",
-        failedAt,
-        from: error.from,
-        to: error.to,
-        documentLines: error.documentLines,
-      };
-    case "overlapping_line_ops":
-      return {
-        error: "overlapping_line_ops",
-        failedAt,
-        conflictsWith: error.conflictsWith,
-      };
-    case "heading_not_found":
-      return {
-        error: "heading_not_found",
-        failedAt,
-        headingPath: error.headingPath,
-      };
-    case "ambiguous_heading":
-      return {
-        error: "ambiguous_heading",
-        failedAt,
-        headingPath: error.headingPath,
-        matchCount: error.matchCount,
-      };
-  }
-}
 
 export async function POST(
   req: NextRequest,

--- a/src/app/api/agent/edits/route.test.ts
+++ b/src/app/api/agent/edits/route.test.ts
@@ -1,0 +1,443 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "@/lib/api-tokens";
+import { getDocBySlug, insertDoc } from "@/lib/db";
+import { generateSlug } from "@/lib/slug";
+import { stripMarkdown } from "@/lib/strip-md";
+import * as RevisionLog from "@/lib/revision-log";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { POST } from "./route";
+
+const TEST_OWNER = "__test_agent_batch__";
+const OTHER_OWNER = "__test_agent_batch_other__";
+
+type ResultRow = {
+  slug: string;
+  status: "ok" | "error";
+  error?: string;
+  failedAt?: number;
+  revisionId?: string | null;
+  doc?: { content: string; title: string };
+};
+type Body = { results: ResultRow[]; dryRun?: boolean };
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set: route tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${OTHER_OWNER}`;
+});
+
+function makeToken() {
+  return createApiToken(TEST_OWNER, "test");
+}
+
+function makeDoc(content: string, ownerId: string = TEST_OWNER) {
+  return insertDoc({
+    slug: generateSlug(),
+    ownerId,
+    title: "Test",
+    content,
+    kind: null,
+    searchText: stripMarkdown(content),
+  });
+}
+
+function postReq(
+  body: unknown,
+  token: string | null,
+  extraHeaders: Record<string, string> = {},
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...extraHeaders,
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
+  const req = new NextRequest("http://localhost/api/agent/edits", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return POST(req);
+}
+
+function find(body: Body, slug: string): ResultRow {
+  const row = body.results.find((r) => r.slug === slug);
+  if (!row) throw new Error(`no result row for slug ${slug}`);
+  return row;
+}
+
+describe("POST /api/agent/edits: happy path", () => {
+  it("applies ops across multiple docs and records an agent revision per written doc", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("alpha foo\n");
+    const b = await makeDoc("beta foo\n");
+    const res = await postReq(
+      {
+        operations: [
+          { slug: a.slug, ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+          { slug: b.slug, ops: [{ type: "replace", find: "foo", replace: "baz" }] },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Body;
+    expect(body.results).toHaveLength(2);
+
+    const byA = find(body, a.slug);
+    const byB = find(body, b.slug);
+    expect(byA.status).toBe("ok");
+    expect(byA.doc?.content).toBe("alpha bar\n");
+    expect(byA.revisionId).toMatch(/^rv_/);
+    expect(byB.status).toBe("ok");
+    expect(byB.doc?.content).toBe("beta baz\n");
+
+    const listedA = await RevisionLog.list(a.id);
+    expect(listedA.revisions).toHaveLength(1);
+    expect(listedA.revisions[0]?.source).toBe("agent");
+  });
+
+  it("applies the batch summary to every written doc's revision", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("alpha foo\n");
+    const res = await postReq(
+      {
+        operations: [
+          { slug: a.slug, ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+        ],
+        summary: "rename foo to bar",
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const listed = await RevisionLog.list(a.id);
+    expect(listed.revisions[0]?.summary).toBe("rename foo to bar");
+  });
+
+  it("supports setContent per entry and re-derives the title from the new H1", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("# Old\n\nbody\n");
+    const res = await postReq(
+      {
+        operations: [
+          {
+            slug: a.slug,
+            ops: [{ type: "setContent", content: "# Fresh Title\n\nnew body\n" }],
+          },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const byA = find((await res.json()) as Body, a.slug);
+    expect(byA.status).toBe("ok");
+    expect(byA.doc?.title).toBe("Fresh Title");
+    expect(byA.doc?.content).toBe("# Fresh Title\n\nnew body\n");
+  });
+
+  it("does not record a revision for a doc whose ops produce identical content", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("foo bar\n");
+    const res = await postReq(
+      {
+        operations: [
+          { slug: a.slug, ops: [{ type: "replace", find: "foo", replace: "foo" }] },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const byA = find((await res.json()) as Body, a.slug);
+    expect(byA.status).toBe("ok");
+    expect(byA.revisionId).toBeNull();
+    expect((await RevisionLog.list(a.id)).revisions).toHaveLength(0);
+  });
+});
+
+describe("POST /api/agent/edits: per-doc isolation", () => {
+  it("reports per-doc success and failure independently", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("alpha foo\n");
+    const b = await makeDoc("no match here\n");
+    const res = await postReq(
+      {
+        operations: [
+          { slug: a.slug, ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+          {
+            slug: b.slug,
+            ops: [{ type: "replace", find: "missing", replace: "x" }],
+          },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Body;
+    expect(find(body, a.slug).status).toBe("ok");
+    expect(find(body, b.slug).status).toBe("error");
+    expect(find(body, b.slug).error).toBe("no_match");
+
+    // The successful doc landed even though its sibling failed.
+    expect((await getDocBySlug(a.slug))?.content).toBe("alpha bar\n");
+    expect((await getDocBySlug(b.slug))?.content).toBe("no match here\n");
+    expect((await RevisionLog.list(b.id)).revisions).toHaveLength(0);
+  });
+
+  it("rolls back a whole doc's batch when one of its later ops fails", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("one\ntwo\nthree\n");
+    const res = await postReq(
+      {
+        operations: [
+          {
+            slug: a.slug,
+            ops: [
+              { type: "replace", find: "two", replace: "TWO" },
+              { type: "insertAfterLine", line: 99, content: "x" },
+            ],
+          },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const byA = find((await res.json()) as Body, a.slug);
+    expect(byA.status).toBe("error");
+    expect(byA.error).toBe("line_out_of_range");
+    expect(byA.failedAt).toBe(1);
+    // The earlier op did not partially apply.
+    expect((await getDocBySlug(a.slug))?.content).toBe("one\ntwo\nthree\n");
+  });
+
+  it("returns a per-doc not_found error for an unknown slug", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("alpha foo\n");
+    const res = await postReq(
+      {
+        operations: [
+          { slug: a.slug, ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+          {
+            slug: "nonexistent-slug-xyz",
+            ops: [{ type: "replace", find: "a", replace: "b" }],
+          },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Body;
+    expect(find(body, a.slug).status).toBe("ok");
+    expect(find(body, "nonexistent-slug-xyz").status).toBe("error");
+    expect(find(body, "nonexistent-slug-xyz").error).toBe("not_found");
+  });
+
+  it("returns a per-doc not_found error for a slug owned by someone else", async () => {
+    const token = await makeToken();
+    const mine = await makeDoc("alpha foo\n");
+    const theirs = await makeDoc("their body\n", OTHER_OWNER);
+    const res = await postReq(
+      {
+        operations: [
+          {
+            slug: mine.slug,
+            ops: [{ type: "replace", find: "foo", replace: "bar" }],
+          },
+          {
+            slug: theirs.slug,
+            ops: [{ type: "replace", find: "their", replace: "hijacked" }],
+          },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Body;
+    expect(find(body, mine.slug).status).toBe("ok");
+    expect(find(body, theirs.slug).error).toBe("not_found");
+    // The other owner's doc was never touched.
+    expect((await getDocBySlug(theirs.slug))?.content).toBe("their body\n");
+  });
+
+  it("returns a per-doc content_too_large error without blocking sibling docs", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("alpha seed\n");
+    const b = await makeDoc("beta foo\n");
+    const huge = "x".repeat(1024 * 1024 + 10);
+    const res = await postReq(
+      {
+        operations: [
+          { slug: a.slug, ops: [{ type: "replace", find: "seed", replace: huge }] },
+          { slug: b.slug, ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Body;
+    expect(find(body, a.slug).error).toBe("content_too_large");
+    expect(find(body, b.slug).status).toBe("ok");
+    expect((await getDocBySlug(b.slug))?.content).toBe("beta bar\n");
+  });
+});
+
+describe("POST /api/agent/edits: dryRun", () => {
+  it("previews every doc without writing or recording revisions", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("alpha foo\n");
+    const b = await makeDoc("beta foo\n");
+    const res = await postReq(
+      {
+        operations: [
+          { slug: a.slug, ops: [{ type: "replace", find: "foo", replace: "bar" }] },
+          { slug: b.slug, ops: [{ type: "replace", find: "foo", replace: "baz" }] },
+        ],
+        dryRun: true,
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Body;
+    expect(body.dryRun).toBe(true);
+
+    const byA = find(body, a.slug);
+    expect(byA.status).toBe("ok");
+    expect(byA.doc?.content).toBe("alpha bar\n");
+    expect(byA.revisionId).toBeNull();
+
+    expect((await getDocBySlug(a.slug))?.content).toBe("alpha foo\n");
+    expect((await getDocBySlug(b.slug))?.content).toBe("beta foo\n");
+    expect((await RevisionLog.list(a.id)).revisions).toHaveLength(0);
+  });
+
+  it("reports per-doc errors in a dryRun without writing", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("alpha foo\n");
+    const res = await postReq(
+      {
+        operations: [
+          {
+            slug: a.slug,
+            ops: [{ type: "replace", find: "missing", replace: "x" }],
+          },
+        ],
+        dryRun: true,
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const byA = find((await res.json()) as Body, a.slug);
+    expect(byA.status).toBe("error");
+    expect(byA.error).toBe("no_match");
+  });
+});
+
+describe("POST /api/agent/edits: auth and shape errors", () => {
+  it("returns 401 when no auth is provided", async () => {
+    const a = await makeDoc("x\n");
+    const res = await postReq(
+      {
+        operations: [
+          { slug: a.slug, ops: [{ type: "replace", find: "x", replace: "y" }] },
+        ],
+      },
+      null,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const token = await makeToken();
+    const req = new NextRequest("http://localhost/api/agent/edits", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token.plaintext}`,
+      },
+      body: "{not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when operations is missing", async () => {
+    const token = await makeToken();
+    const res = await postReq({}, token.plaintext);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when operations is an empty array", async () => {
+    const token = await makeToken();
+    const res = await postReq({ operations: [] }, token.plaintext);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 with the entry index when an entry's ops are malformed", async () => {
+    const token = await makeToken();
+    const res = await postReq(
+      {
+        operations: [
+          { slug: "aaa", ops: [{ type: "replace", find: "x", replace: "y" }] },
+          { slug: "bbb", ops: [{ type: "deleteLineRange", from: 5, to: 1 }] },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/operations\[1\]/);
+  });
+
+  it("returns 400 for a duplicate slug", async () => {
+    const token = await makeToken();
+    const res = await postReq(
+      {
+        operations: [
+          { slug: "dup", ops: [{ type: "replace", find: "x", replace: "y" }] },
+          { slug: "dup", ops: [{ type: "replace", find: "a", replace: "b" }] },
+        ],
+      },
+      token.plaintext,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the batch exceeds the per-request doc cap", async () => {
+    const token = await makeToken();
+    const operations = Array.from({ length: 51 }, (_, i) => ({
+      slug: `slug-${i}`,
+      ops: [{ type: "replace", find: "x", replace: "y" }],
+    }));
+    const res = await postReq({ operations }, token.plaintext);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 413 when the request declares a body larger than the cap", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("seed\n");
+    const res = await postReq(
+      {
+        operations: [
+          { slug: a.slug, ops: [{ type: "replace", find: "seed", replace: "x" }] },
+        ],
+      },
+      token.plaintext,
+      { "content-length": String(5 * 1024 * 1024) },
+    );
+    expect(res.status).toBe(413);
+  });
+});

--- a/src/app/api/agent/edits/route.ts
+++ b/src/app/api/agent/edits/route.ts
@@ -1,0 +1,277 @@
+import { NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/lib/auth";
+import { getDocBySlug, type Doc } from "@/lib/db";
+import { writeDocContent } from "@/lib/doc-mutation-path";
+import { resolveTitle } from "@/lib/title";
+import { stripMarkdown } from "@/lib/strip-md";
+import { applierErrorBody, jsonError } from "@/lib/route-helpers";
+import { parseDocEditBatch, type DocEditEntry } from "@/lib/edit-op-schema";
+import { apply, type MatchPreview } from "@/lib/operation-applier";
+
+/**
+ * Ceiling on the declared request body. A batch legitimately carries several
+ * documents, so this is larger than the 1 MB single-doc limit, while still
+ * bounding how much one call asks the server to buffer.
+ */
+const MAX_REQUEST_BYTES = 4 * 1024 * 1024;
+
+/** Per-document content ceiling, matching the single-doc edit/upload limit. */
+const MAX_DOC_BYTES = 1024 * 1024;
+
+/** Cap on documents per batch, bounding the DB round-trips one call triggers. */
+const MAX_BATCH_DOCS = 50;
+
+type AgentDocView = {
+  id: string;
+  slug: string;
+  title: string;
+  kind: string | null;
+  tags: string[];
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/**
+ * One document's outcome in a cross-document batch. Every variant carries the
+ * `slug` so a caller can correlate it to the request entry; `status`
+ * discriminates success from failure. Error variants mirror the single-doc
+ * `/edits` failure bodies so agents parse both surfaces the same way.
+ */
+type DocResult =
+  | { slug: string; status: "ok"; doc: AgentDocView; revisionId: string | null }
+  | { slug: string; status: "error"; error: "not_found" }
+  | { slug: string; status: "error"; error: "content_too_large" }
+  | {
+      slug: string;
+      status: "error";
+      error: "no_match";
+      failedAt: number;
+      query: string;
+    }
+  | {
+      slug: string;
+      status: "error";
+      error: "ambiguous_match";
+      failedAt: number;
+      query: string;
+      matchCount: number;
+      matches: MatchPreview[];
+    }
+  | {
+      slug: string;
+      status: "error";
+      error: "line_out_of_range";
+      failedAt: number;
+      line: number;
+      documentLines: number;
+    }
+  | {
+      slug: string;
+      status: "error";
+      error: "range_out_of_range";
+      failedAt: number;
+      from: number;
+      to: number;
+      documentLines: number;
+    }
+  | {
+      slug: string;
+      status: "error";
+      error: "overlapping_line_ops";
+      failedAt: number;
+      conflictsWith: number;
+    }
+  | {
+      slug: string;
+      status: "error";
+      error: "heading_not_found";
+      failedAt: number;
+      headingPath: string[];
+    }
+  | {
+      slug: string;
+      status: "error";
+      error: "ambiguous_heading";
+      failedAt: number;
+      headingPath: string[];
+      matchCount: number;
+    };
+
+type Body = { operations?: unknown; summary?: unknown; dryRun?: unknown };
+
+type EntryOptions = {
+  ownerId: string;
+  summary: string | null;
+  dryRun: boolean;
+};
+
+function toDocView(doc: Doc, title: string, content: string): AgentDocView {
+  return {
+    id: doc.id,
+    slug: doc.slug,
+    title,
+    kind: doc.kind,
+    tags: doc.tags,
+    content,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+  };
+}
+
+/**
+ * Applies one document's ops and persists them. Per-document atomic: the ops
+ * either all land in a single revision or none do. Resolves to a `DocResult`
+ * for every outcome (including failures) so the caller can keep going and
+ * report on sibling documents.
+ */
+async function applyEntry(
+  entry: DocEditEntry,
+  opts: EntryOptions,
+): Promise<DocResult> {
+  const { slug, ops } = entry;
+
+  const doc = await getDocBySlug(slug);
+  if (!doc || doc.ownerId !== opts.ownerId) {
+    return { slug, status: "error", error: "not_found" };
+  }
+
+  const applied = apply(doc.content, ops);
+  if (!applied.ok) {
+    return {
+      slug,
+      status: "error",
+      ...applierErrorBody(applied.error, applied.failedAt),
+    };
+  }
+
+  if (Buffer.byteLength(applied.content, "utf8") > MAX_DOC_BYTES) {
+    return { slug, status: "error", error: "content_too_large" };
+  }
+
+  // setContent is a "save as": re-derive the title from the new H1 the way
+  // upload does. Every other op preserves the existing title.
+  const isSetContent = ops.length === 1 && ops[0]!.type === "setContent";
+  const nextTitle = isSetContent
+    ? resolveTitle(applied.content, undefined)
+    : resolveTitle(applied.content, doc.title);
+
+  if (opts.dryRun) {
+    return {
+      slug,
+      status: "ok",
+      doc: toDocView(doc, nextTitle, applied.content),
+      revisionId: null,
+    };
+  }
+
+  // A batch that resolves to the existing content should not burn a retention
+  // slot, mirroring the single-doc route's no-op short-circuit.
+  if (applied.content === doc.content) {
+    return {
+      slug,
+      status: "ok",
+      doc: toDocView(doc, doc.title, doc.content),
+      revisionId: null,
+    };
+  }
+
+  const writeResult = await writeDocContent({
+    docId: doc.id,
+    newContent: applied.content,
+    newTitle: nextTitle,
+    newSearchText: stripMarkdown(applied.content),
+    summary: opts.summary,
+    source: "agent",
+    ownerId: opts.ownerId,
+  });
+  if (!writeResult.ok) {
+    throw new Error(
+      `writeDocContent reported a revision mismatch for ${slug}; the cross-doc batch sends no expectedRevisionId, so this signals a broken invariant`,
+    );
+  }
+
+  return {
+    slug,
+    status: "ok",
+    doc: toDocView(writeResult.doc, writeResult.doc.title, writeResult.doc.content),
+    revisionId: writeResult.revisionId,
+  };
+}
+
+export async function POST(req: NextRequest) {
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && parseInt(contentLength, 10) > MAX_REQUEST_BYTES) {
+    return jsonError(413, "Request body exceeds 4MB limit");
+  }
+
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return jsonError(400, "Invalid JSON body");
+  }
+  if (typeof body !== "object" || body === null) {
+    return jsonError(400, "JSON body required");
+  }
+
+  let summary: string | null = null;
+  if (body.summary !== undefined) {
+    if (body.summary !== null && typeof body.summary !== "string") {
+      return jsonError(400, "summary must be a string or null");
+    }
+    summary = body.summary;
+  }
+
+  let dryRun = false;
+  if (body.dryRun !== undefined) {
+    if (typeof body.dryRun !== "boolean") {
+      return jsonError(400, "dryRun must be a boolean");
+    }
+    dryRun = body.dryRun;
+  }
+
+  const parsed = parseDocEditBatch(body.operations);
+  if (!parsed.ok) {
+    return jsonError(400, parsed.error);
+  }
+  if (parsed.entries.length > MAX_BATCH_DOCS) {
+    return jsonError(
+      400,
+      `operations may include at most ${MAX_BATCH_DOCS} documents per batch`,
+    );
+  }
+
+  const auth = await requireAuth(req);
+  if (!auth.authenticated) {
+    return jsonError(auth.status, auth.reason);
+  }
+
+  // Per-document atomic, batch best-effort: each entry runs through its own
+  // OperationApplier pass and DocMutationPath transaction. A failure on one
+  // document does not roll back or block the others.
+  const opts: EntryOptions = { ownerId: auth.ownerId, summary, dryRun };
+  const results: DocResult[] = [];
+  for (const entry of parsed.entries) {
+    results.push(await applyEntry(entry, opts));
+  }
+
+  // Revalidate only documents that actually changed. dryRun and no-op results
+  // carry a null revisionId, so they fall out here naturally.
+  const writtenSlugs = results
+    .filter((r) => r.status === "ok" && r.revisionId !== null)
+    .map((r) => r.slug);
+  if (writtenSlugs.length > 0) {
+    revalidatePath("/");
+    for (const slug of writtenSlugs) {
+      revalidatePath(`/v/${slug}`);
+    }
+  }
+
+  const responseBody = dryRun ? { results, dryRun: true } : { results };
+  return new Response(JSON.stringify(responseBody), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/lib/edit-op-schema.test.ts
+++ b/src/lib/edit-op-schema.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseEditOp, parseEditOps, type EditOp } from "./edit-op-schema";
+import {
+  parseEditOp,
+  parseEditOps,
+  parseDocEditBatch,
+  type EditOp,
+} from "./edit-op-schema";
 
 describe("parseEditOp — replace", () => {
   it("accepts a minimal replace op", () => {
@@ -374,6 +379,89 @@ describe("parseEditOps (batch)", () => {
     if (!result.ok) {
       expect(result.error).toMatch(/\[1\]|index 1|second/i);
     }
+  });
+});
+
+describe("parseDocEditBatch", () => {
+  it("accepts a batch of per-doc entries", () => {
+    const result = parseDocEditBatch([
+      { slug: "aaa", ops: [{ type: "replace", find: "x", replace: "y" }] },
+      { slug: "bbb", ops: [{ type: "setContent", content: "# New" }] },
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.entries).toHaveLength(2);
+      expect(result.entries[0]!.slug).toBe("aaa");
+      expect(result.entries[0]!.ops[0]).toEqual({
+        type: "replace",
+        find: "x",
+        replace: "y",
+        replaceAll: false,
+      });
+      expect(result.entries[1]!.slug).toBe("bbb");
+    }
+  });
+
+  it("rejects a non-array", () => {
+    expect(parseDocEditBatch({}).ok).toBe(false);
+    expect(parseDocEditBatch("nope").ok).toBe(false);
+    expect(parseDocEditBatch(null).ok).toBe(false);
+  });
+
+  it("rejects an empty array", () => {
+    const result = parseDocEditBatch([]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/empty|at least/i);
+  });
+
+  it("rejects an entry that is not an object", () => {
+    const result = parseDocEditBatch(["nope"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/operations\[0\]/);
+  });
+
+  it("rejects an entry with a missing or empty slug", () => {
+    expect(
+      parseDocEditBatch([
+        { ops: [{ type: "replace", find: "x", replace: "y" }] },
+      ]).ok,
+    ).toBe(false);
+    const result = parseDocEditBatch([
+      { slug: "", ops: [{ type: "replace", find: "x", replace: "y" }] },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/operations\[0\].*slug/i);
+  });
+
+  it("reports the entry index when an entry's ops fail validation", () => {
+    const result = parseDocEditBatch([
+      { slug: "aaa", ops: [{ type: "replace", find: "x", replace: "y" }] },
+      { slug: "bbb", ops: [{ type: "deleteLineRange", from: 5, to: 1 }] },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/operations\[1\]/);
+  });
+
+  it("rejects a duplicate slug", () => {
+    const result = parseDocEditBatch([
+      { slug: "dup", ops: [{ type: "replace", find: "x", replace: "y" }] },
+      { slug: "dup", ops: [{ type: "replace", find: "a", replace: "b" }] },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/duplicate/i);
+  });
+
+  it("propagates setContent exclusivity into each entry", () => {
+    const result = parseDocEditBatch([
+      {
+        slug: "aaa",
+        ops: [
+          { type: "setContent", content: "x" },
+          { type: "replace", find: "a", replace: "b" },
+        ],
+      },
+    ]);
+    expect(result.ok).toBe(false);
   });
 });
 

--- a/src/lib/edit-op-schema.ts
+++ b/src/lib/edit-op-schema.ts
@@ -293,6 +293,65 @@ export function parseEditOp(input: unknown): ParseResult<EditOp> {
   }
 }
 
+/**
+ * One document's worth of work in a cross-document edit batch: a slug paired
+ * with the ops to apply to that doc. Produced by {@link parseDocEditBatch}.
+ */
+export type DocEditEntry = {
+  slug: string;
+  ops: EditOp[];
+};
+
+export type ParseDocEditBatchResult =
+  | { ok: true; entries: DocEditEntry[] }
+  | { ok: false; error: string };
+
+/**
+ * Parses the `operations` array of a cross-document edit batch. Each element
+ * is a `{slug, ops}` entry; `ops` runs through {@link parseEditOps}, so per-op
+ * shape rules and setContent exclusivity apply per entry. A slug may appear at
+ * most once: two entries for the same doc would both resolve against the
+ * pre-batch snapshot, so the second write would clobber the first.
+ */
+export function parseDocEditBatch(input: unknown): ParseDocEditBatchResult {
+  if (!Array.isArray(input)) {
+    return { ok: false, error: "operations must be an array" };
+  }
+  if (input.length === 0) {
+    return { ok: false, error: "operations must contain at least one entry" };
+  }
+  const entries: DocEditEntry[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < input.length; i++) {
+    const entry = input[i];
+    if (!isPlainObject(entry)) {
+      return {
+        ok: false,
+        error: `operations[${i}]: entry must be a plain object`,
+      };
+    }
+    if (typeof entry.slug !== "string" || entry.slug.length === 0) {
+      return {
+        ok: false,
+        error: `operations[${i}]: slug must be a non-empty string`,
+      };
+    }
+    if (seen.has(entry.slug)) {
+      return {
+        ok: false,
+        error: `operations[${i}]: duplicate slug "${entry.slug}" (each slug may appear once)`,
+      };
+    }
+    const parsed = parseEditOps(entry.ops);
+    if (!parsed.ok) {
+      return { ok: false, error: `operations[${i}]: ${parsed.error}` };
+    }
+    seen.add(entry.slug);
+    entries.push({ slug: entry.slug, ops: parsed.ops });
+  }
+  return { ok: true, entries };
+}
+
 export function parseEditOps(input: unknown): ParseBatchResult {
   if (!Array.isArray(input)) {
     return { ok: false, error: "ops must be an array" };

--- a/src/lib/route-helpers.ts
+++ b/src/lib/route-helpers.ts
@@ -1,5 +1,6 @@
 import { requireAuth, type AuthResult } from "@/lib/auth";
 import { getDocBySlug, type Doc } from "@/lib/db";
+import type { ApplierError, MatchPreview } from "@/lib/operation-applier";
 
 export type AuthSuccess = Extract<AuthResult, { authenticated: true }>;
 
@@ -27,4 +28,94 @@ export async function requireOwnedDoc(
     return { ok: false, response: jsonError(404, "Document not found") };
   }
   return { ok: true, auth, doc };
+}
+
+/**
+ * JSON error body for an OperationApplier failure. Discriminated on `error`,
+ * mirroring the `ApplierError` kinds, plus `failedAt`: the 0-indexed op that
+ * failed within its doc's batch. Shared by the single-doc `/edits` route and
+ * the cross-document `/api/agent/edits` route so both report failures the
+ * same way.
+ */
+export type AgentApplierErrorBody =
+  | { error: "no_match"; failedAt: number; query: string }
+  | {
+      error: "ambiguous_match";
+      failedAt: number;
+      query: string;
+      matchCount: number;
+      matches: MatchPreview[];
+    }
+  | {
+      error: "line_out_of_range";
+      failedAt: number;
+      line: number;
+      documentLines: number;
+    }
+  | {
+      error: "range_out_of_range";
+      failedAt: number;
+      from: number;
+      to: number;
+      documentLines: number;
+    }
+  | { error: "overlapping_line_ops"; failedAt: number; conflictsWith: number }
+  | { error: "heading_not_found"; failedAt: number; headingPath: string[] }
+  | {
+      error: "ambiguous_heading";
+      failedAt: number;
+      headingPath: string[];
+      matchCount: number;
+    };
+
+export function applierErrorBody(
+  error: ApplierError,
+  failedAt: number,
+): AgentApplierErrorBody {
+  switch (error.kind) {
+    case "no_match":
+      return { error: "no_match", failedAt, query: error.query };
+    case "ambiguous_match":
+      return {
+        error: "ambiguous_match",
+        failedAt,
+        query: error.query,
+        matchCount: error.matchCount,
+        matches: error.matches,
+      };
+    case "line_out_of_range":
+      return {
+        error: "line_out_of_range",
+        failedAt,
+        line: error.line,
+        documentLines: error.documentLines,
+      };
+    case "range_out_of_range":
+      return {
+        error: "range_out_of_range",
+        failedAt,
+        from: error.from,
+        to: error.to,
+        documentLines: error.documentLines,
+      };
+    case "overlapping_line_ops":
+      return {
+        error: "overlapping_line_ops",
+        failedAt,
+        conflictsWith: error.conflictsWith,
+      };
+    case "heading_not_found":
+      return {
+        error: "heading_not_found",
+        failedAt,
+        headingPath: error.headingPath,
+      };
+    case "ambiguous_heading":
+      return {
+        error: "ambiguous_heading",
+        failedAt,
+        headingPath: error.headingPath,
+        matchCount: error.matchCount,
+      };
+  }
 }


### PR DESCRIPTION
Closes #53.

Adds `POST /api/agent/edits`: one request mutates many docs, with consolidated per-doc reporting.

## Endpoint shape

Body: `{operations: [{slug, ops}], summary?: string|null, dryRun?: boolean}`. Each entry's `ops` follows the same rules as the single-doc API (every op type, snapshot-vs-running resolution, `setContent` exclusivity).

Always returns **200** with a per-doc `results` array of discriminated rows:

```json
{
  "results": [
    {"slug": "...", "status": "ok", "doc": {...}, "revisionId": "rv_..."},
    {"slug": "...", "status": "error", "error": "no_match", "failedAt": 0, "query": "..."}
  ]
}
```

Per-doc errors: `not_found`, `content_too_large`, and the full applier-error family with `failedAt`. Request-level guards (single status): 400 for malformed JSON / missing or empty `operations` / malformed op (names `operations[i]`) / duplicate slug / >50 docs; 401 unauthenticated; 413 declared body >4 MB.

## Atomicity model

Per-document atomic, batch best-effort. Each entry runs its own `OperationApplier` pass and `DocMutationPath` transaction, so one doc failing does not roll back or block siblings. A doc whose ops resolve to identical content does not burn a retention slot (mirrors the single-doc no-op short-circuit). `dryRun: true` previews every doc without writing any.

## Decisions worth flagging

- **Always 200, never 207.** The batch request itself succeeded; per-doc outcomes live in the body. Simpler for agents to parse.
- **No `If-Match` on the batch endpoint.** A single header cannot address N docs. Agents that need optimistic concurrency edit individually through `POST /api/agent/docs/<slug>/edits`.
- **Duplicate slugs rejected at parse time.** Two entries for one doc would both resolve against the pre-batch snapshot; the second would clobber the first.

## Shared error mapping

Pulled `applierErrorBody` (and a typed `AgentApplierErrorBody`) out of the single-doc route into `src/lib/route-helpers.ts` so both edit surfaces map applier failures identically. The single-doc route is otherwise untouched.

## Skill

`.claude/skills/md-niftymonkey/SKILL.md` gains a "Cross-document edits" section documenting the contract and the results array; the frontmatter description picks up fan-out triggers. CI sync resyncs the hosted copy on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch editing capability to apply operations across multiple documents in a single request, with per-document success/failure reporting and optional dry-run mode.

* **Documentation**
  * Updated skill documentation to comprehensively cover all markdown operations and formatting consistency guidelines.

* **Bug Fixes**
  * Improved error handling and validation for edit operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/md/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->