### PR TITLE
feat(agent-api): add owner-scoped search endpoint with per-match contexts

### DIFF
--- a/.claude/skills/md-niftymonkey/SKILL.md
+++ b/.claude/skills/md-niftymonkey/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: md-niftymonkey
-description: Work with markdown on md.niftymonkey.dev: upload, fetch, edit, list, and delete. Use when the user asks to upload, share, or publish markdown to md.niftymonkey.dev, fetch a doc back, make targeted edits to an existing doc, replace a section by heading, preview an edit before committing, save a fresh full-doc version, coordinate edits with optimistic concurrency, or apply one set of edits across many docs at once. Triggers on phrases like "upload this to md.niftymonkey", "share this as a markdown link", "put this on md", "fix the typo on my md doc", "update the md doc at <slug>", "rewrite the API section on <slug>", "preview this edit on md", "rename a term across all my md docs", or pointing at a `.md` file with intent to share or modify on this service. Handles atomic find/replace, line-addressed edits, heading-addressed section replacement, dry-run validation, If-Match optimistic concurrency, cross-document batch edits, and structured retry errors.
+description: Work with markdown on md.niftymonkey.dev: upload, fetch, search, edit, list, and delete. Use when the user asks to upload, share, or publish markdown to md.niftymonkey.dev, fetch a doc back, find which of their docs mention a term, make targeted edits to an existing doc, replace a section by heading, preview an edit before committing, save a fresh full-doc version, coordinate edits with optimistic concurrency, or apply one set of edits across many docs at once. Triggers on phrases like "upload this to md.niftymonkey", "share this as a markdown link", "put this on md", "fix the typo on my md doc", "update the md doc at <slug>", "rewrite the API section on <slug>", "preview this edit on md", "rename a term across all my md docs", "which of my md docs mention X", or pointing at a `.md` file with intent to share or modify on this service. Handles atomic find/replace, line-addressed edits, heading-addressed section replacement, dry-run validation, If-Match optimistic concurrency, cross-document batch edits, owner-scoped full-text search with per-match contexts, and structured retry errors.
 ---
 
 # md-niftymonkey
@@ -355,6 +355,51 @@ Per-doc `error` values: `not_found` (slug unknown or owned by someone else), `co
 Request-level problems fail the whole call before any doc is touched: malformed JSON, a missing or empty `operations` array, a malformed op (400, naming the offending `operations[i]`), a duplicate slug (400), more than 50 docs (400), or a declared body over 4 MB (413). 401 if unauthenticated.
 
 `If-Match` optimistic concurrency is single-doc only. The batch endpoint does not accept it; when a write must be guarded against an intervening change, edit that doc through `POST /api/agent/docs/<slug>/edits` with `If-Match`.
+
+## Search
+
+`GET /api/agent/search?q=<query>` finds owned docs whose content matches `q` and returns per-match contexts (line, column, surrounding lines). Use this before edits when you don't already know which slug to touch.
+
+```bash
+curl -sS "https://md.niftymonkey.dev/api/agent/search?q=needle" \
+  -H "Authorization: Bearer $MD_API_KEY"
+```
+
+Query params: `q` (required, non-empty), `limit` (optional, default 20, max 100).
+
+Response shape:
+
+```json
+{
+  "docs": [
+    {
+      "slug": "abc",
+      "title": "Title",
+      "kind": "essay",
+      "tags": ["foo"],
+      "matchCount": 7,
+      "matches": [
+        {
+          "line": 47,
+          "column": 1,
+          "previewLines": [
+            {"line": 46, "text": "..."},
+            {"line": 47, "text": "..."},
+            {"line": 48, "text": "..."}
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+- **Two-stage matching.** Full-text search narrows the candidate docs, then a literal substring scan extracts per-match contexts. A doc surfaces only if `q` appears literally in its content; case-sensitive (matching the single-doc `replace` op). Stem-only or case-mismatch hits drop out.
+- **`matchCount` is the true total**; `matches[]` is capped at 5 per doc, with one line of context on either side. Same `{line, column, previewLines}` shape the edits endpoint uses for `ambiguous_match`.
+- **Owner-scoped.** Only docs uploaded under the calling token's owner are visible.
+- **No cursor pagination.** Tighten `q` or raise `limit` (max 100). For broad listing, use `/api/list?search=` instead.
+
+Errors: 400 if `q` is missing, empty, or whitespace-only. 401 if unauthenticated.
 
 ## List
 

--- a/src/app/api/agent/search/route.test.ts
+++ b/src/app/api/agent/search/route.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createApiToken } from "@/lib/api-tokens";
+import { insertDoc } from "@/lib/db";
+import { generateSlug } from "@/lib/slug";
+import { stripMarkdown } from "@/lib/strip-md";
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(async () => ({ user: null })),
+}));
+
+import { GET } from "./route";
+
+const TEST_OWNER = "__test_agent_search__";
+const OTHER_OWNER = "__test_agent_search_other__";
+
+type Preview = { line: number; text: string };
+type Match = { line: number; column: number; previewLines: Preview[] };
+type DocRow = {
+  slug: string;
+  title: string;
+  kind: string | null;
+  tags: string[];
+  matchCount: number;
+  matches: Match[];
+};
+type Body = { docs: DocRow[] };
+
+beforeAll(() => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL not set: route tests need .env.local.");
+  }
+});
+
+afterAll(async () => {
+  await sql`DELETE FROM api_tokens WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${TEST_OWNER}`;
+  await sql`DELETE FROM docs WHERE owner_id = ${OTHER_OWNER}`;
+});
+
+function makeToken() {
+  return createApiToken(TEST_OWNER, "test");
+}
+
+function makeDoc(
+  content: string,
+  opts: {
+    title?: string;
+    ownerId?: string;
+    kind?: string | null;
+    tags?: string[];
+  } = {},
+) {
+  return insertDoc({
+    slug: generateSlug(),
+    ownerId: opts.ownerId ?? TEST_OWNER,
+    title: opts.title ?? "Test",
+    content,
+    kind: opts.kind ?? null,
+    tags: opts.tags,
+    searchText: stripMarkdown(content),
+  });
+}
+
+function getReq(
+  params: Record<string, string>,
+  token: string | null,
+) {
+  const headers: Record<string, string> = {};
+  if (token) headers.authorization = `Bearer ${token}`;
+  const url = `http://localhost/api/agent/search?${new URLSearchParams(params).toString()}`;
+  const req = new NextRequest(url, { method: "GET", headers });
+  return GET(req);
+}
+
+describe("GET /api/agent/search: happy path", () => {
+  it("returns matching docs with per-match contexts", async () => {
+    const token = await makeToken();
+    const a = await makeDoc(
+      [
+        "intro line",
+        "first happypathneedle here",
+        "trailing line",
+        "more body",
+        "second happypathneedle there",
+        "",
+      ].join("\n"),
+      { title: "Doc A" },
+    );
+    await makeDoc("nothing relevant\n", { title: "Doc B" });
+
+    const res = await getReq({ q: "happypathneedle" }, token.plaintext);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Body;
+
+    const found = body.docs.find((d) => d.slug === a.slug);
+    expect(found).toBeDefined();
+    expect(found!.title).toBe("Doc A");
+    expect(found!.matchCount).toBe(2);
+    expect(found!.matches).toHaveLength(2);
+    expect(found!.matches[0]!.line).toBe(2);
+    expect(found!.matches[1]!.line).toBe(5);
+    expect(
+      found!.matches[0]!.previewLines.some((p) =>
+        p.text.includes("happypathneedle"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns an empty docs array when nothing matches", async () => {
+    const token = await makeToken();
+    const res = await getReq(
+      { q: "noresultsphraseunused999" },
+      token.plaintext,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Body;
+    expect(body.docs).toEqual([]);
+  });
+
+  it("returns kind and tags on each matching doc", async () => {
+    const token = await makeToken();
+    const a = await makeDoc("alpha kindtagsneedle body\n", {
+      kind: "essay",
+      tags: ["foo", "bar"],
+    });
+    const res = await getReq({ q: "kindtagsneedle" }, token.plaintext);
+    const body = (await res.json()) as Body;
+    const found = body.docs.find((d) => d.slug === a.slug)!;
+    expect(found.kind).toBe("essay");
+    expect(found.tags).toEqual(expect.arrayContaining(["foo", "bar"]));
+  });
+
+  it("caps matches per doc at 5 but reports the true matchCount", async () => {
+    const token = await makeToken();
+    const lines = Array.from(
+      { length: 10 },
+      (_, i) => `line ${i + 1} capneedle marker`,
+    ).join("\n");
+    const a = await makeDoc(lines + "\n");
+    const res = await getReq({ q: "capneedle" }, token.plaintext);
+    const body = (await res.json()) as Body;
+    const found = body.docs.find((d) => d.slug === a.slug)!;
+    expect(found.matchCount).toBe(10);
+    expect(found.matches).toHaveLength(5);
+  });
+});
+
+describe("GET /api/agent/search: scoping and filtering", () => {
+  it("only returns docs owned by the caller", async () => {
+    const token = await makeToken();
+    const mine = await makeDoc("alpha ownerscopedneedle mine\n");
+    const theirs = await makeDoc("beta ownerscopedneedle theirs\n", {
+      ownerId: OTHER_OWNER,
+    });
+    const res = await getReq({ q: "ownerscopedneedle" }, token.plaintext);
+    const body = (await res.json()) as Body;
+    const slugs = body.docs.map((d) => d.slug);
+    expect(slugs).toContain(mine.slug);
+    expect(slugs).not.toContain(theirs.slug);
+  });
+
+  it("excludes docs where FTS matches but the literal substring does not", async () => {
+    const token = await makeToken();
+    // FTS lowercases tokens; findMatches is case-sensitive. A doc that only
+    // contains the capitalized form should NOT appear when searching for the
+    // lowercase form.
+    const capOnly = await makeDoc("CapsLiteralNeedle word here\n");
+    const lowerExact = await makeDoc("capsliteralneedle word here\n");
+    const res = await getReq({ q: "capsliteralneedle" }, token.plaintext);
+    const body = (await res.json()) as Body;
+    const slugs = body.docs.map((d) => d.slug);
+    expect(slugs).toContain(lowerExact.slug);
+    expect(slugs).not.toContain(capOnly.slug);
+  });
+
+  it("honors the limit query parameter", async () => {
+    const token = await makeToken();
+    for (let i = 0; i < 4; i++) {
+      await makeDoc(`limitparamneedle entry ${i}\n`);
+    }
+    const res = await getReq(
+      { q: "limitparamneedle", limit: "2" },
+      token.plaintext,
+    );
+    const body = (await res.json()) as Body;
+    expect(body.docs.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("GET /api/agent/search: validation and auth", () => {
+  it("returns 400 when q is missing", async () => {
+    const token = await makeToken();
+    const res = await getReq({}, token.plaintext);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when q is empty or whitespace only", async () => {
+    const token = await makeToken();
+    expect((await getReq({ q: "" }, token.plaintext)).status).toBe(400);
+    expect((await getReq({ q: "   " }, token.plaintext)).status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const res = await getReq({ q: "anything" }, null);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/agent/search/route.ts
+++ b/src/app/api/agent/search/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { searchOwnedDocsFullText } from "@/lib/db";
+import { findMatches, type PreviewLine } from "@/lib/match-resolver";
+import { jsonError } from "@/lib/route-helpers";
+
+/**
+ * Cap on the number of literal matches returned per document. Matches the
+ * `MAX_AMBIGUOUS_PREVIEWS` cap used by the single-doc edits endpoint, so
+ * `matches[]` shapes are consistent across the agent API. `matchCount`
+ * always reports the true total so callers know when previews were trimmed.
+ */
+const MAX_MATCHES_PER_DOC = 5;
+
+/** Default doc cap when `?limit=` is absent or unparseable. */
+const DEFAULT_LIMIT = 20;
+
+/** Hard ceiling on `?limit=`. Mirrors `/api/list`. */
+const MAX_LIMIT = 100;
+
+/**
+ * Number of context lines included on either side of a match. Matches the
+ * `context: 1` setting the edits endpoint uses for ambiguous_match previews.
+ */
+const PREVIEW_CONTEXT = 1;
+
+type DocMatch = {
+  line: number;
+  column: number;
+  previewLines: PreviewLine[];
+};
+
+type ResponseDoc = {
+  slug: string;
+  title: string;
+  kind: string | null;
+  tags: string[];
+  matchCount: number;
+  matches: DocMatch[];
+};
+
+function parseLimit(raw: string | null): number {
+  if (!raw) return DEFAULT_LIMIT;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, n);
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (!auth.authenticated) {
+    return jsonError(auth.status, auth.reason);
+  }
+
+  const { searchParams } = req.nextUrl;
+  const rawQ = searchParams.get("q");
+  if (rawQ === null) {
+    return jsonError(400, "q query parameter is required");
+  }
+  const query = rawQ.trim();
+  if (query.length === 0) {
+    return jsonError(400, "q must not be empty");
+  }
+  const limit = parseLimit(searchParams.get("limit"));
+
+  const candidates = await searchOwnedDocsFullText({
+    ownerId: auth.ownerId,
+    query,
+    limit,
+  });
+
+  // FTS narrows the candidate set; findMatches extracts literal substring
+  // matches in document order. Candidates with no literal match (case
+  // mismatch, stem-only hit, etc.) drop out so the response only carries
+  // results the caller can act on directly.
+  const docs: ResponseDoc[] = [];
+  for (const c of candidates) {
+    const matches = findMatches(c.content, query, { context: PREVIEW_CONTEXT });
+    if (matches.length === 0) continue;
+    docs.push({
+      slug: c.slug,
+      title: c.title,
+      kind: c.kind,
+      tags: c.tags,
+      matchCount: matches.length,
+      matches: matches.slice(0, MAX_MATCHES_PER_DOC).map((m) => ({
+        line: m.line,
+        column: m.column,
+        previewLines: m.previewLines,
+      })),
+    });
+  }
+
+  return new Response(JSON.stringify({ docs }), {
+    status: 200,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -326,6 +326,55 @@ async function runSearchQuery(args: {
   return sql.query<DocSummaryRow>(text, values);
 }
 
+export type DocSearchRow = {
+  slug: string;
+  title: string;
+  kind: string | null;
+  tags: string[];
+  content: string;
+};
+
+/**
+ * Owner-scoped full-text search returning the candidate docs' content along
+ * with their metadata. Caller is expected to run per-doc literal-match
+ * extraction (typically {@link import("./match-resolver").findMatches}) over
+ * `content` and discard candidates whose literal substring is absent. Returns
+ * an empty array when the sanitized FTS query has no tokens.
+ */
+export async function searchOwnedDocsFullText(args: {
+  ownerId: string;
+  query: string;
+  limit: number;
+}): Promise<DocSearchRow[]> {
+  const tsQuery = buildTsQuery(args.query);
+  if (!tsQuery) return [];
+
+  const result = await sql.query<{
+    slug: string;
+    title: string | null;
+    kind: string | null;
+    tags: string[] | null;
+    content: string;
+  }>(
+    `SELECT slug, title, kind, tags, content
+     FROM docs
+     WHERE owner_id = $1
+       AND search_vector @@ to_tsquery('english', $2)
+     ORDER BY ts_rank(search_vector, to_tsquery('english', $2)) DESC,
+              created_at DESC,
+              id DESC
+     LIMIT $3`,
+    [args.ownerId, tsQuery, args.limit],
+  );
+  return result.rows.map((row) => ({
+    slug: row.slug,
+    title: row.title ?? "Untitled",
+    kind: row.kind,
+    tags: row.tags ?? [],
+    content: row.content,
+  }));
+}
+
 export type TagUsageRow = { tag: string; count: number };
 
 /**


### PR DESCRIPTION
Closes #52.

Adds `GET /api/agent/search?q=<query>` so agents can locate the right slug (and the right spot within it) in one call, instead of listing every owned doc, fetching each, and grepping client-side.

## Endpoint shape

```
GET /api/agent/search?q=needle&limit=20
```

Response:

```json
{
  "docs": [
    {
      "slug": "...",
      "title": "...",
      "kind": null,
      "tags": [],
      "matchCount": 7,
      "matches": [
        {"line": 47, "column": 1, "previewLines": [{"line":46,"text":"..."},{"line":47,"text":"..."},{"line":48,"text":"..."}]}
      ]
    }
  ]
}
```

`q` is required and non-empty. `limit` defaults to 20, maxes at 100 (mirrors `/api/list`). 401 if unauthenticated; 400 if `q` is missing/empty/whitespace-only.

## Two-stage matching

1. **FTS narrows the candidate set** by reusing the existing `search_vector` index that already powers `/api/list?search=`. New private DB helper `searchOwnedDocsFullText({ownerId, query, limit})` calls the same `buildTsQuery` sanitizer and pulls back `{slug, title, kind, tags, content}` for each candidate.
2. **`findMatches(content, q, {context: 1})` extracts per-match contexts** for each candidate. A candidate is dropped if no literal match is found (case mismatch, stem-only FTS hit, etc.), so every returned doc has actionable matches.

`matchCount` always reports the true total; `matches[]` is capped at 5 per doc (the same `MAX_AMBIGUOUS_PREVIEWS` rule the edits endpoint uses), with one line of context on either side. Same `{line, column, previewLines}` shape agents already see for `ambiguous_match`, so callers parse one preview format across the API.

## Decisions worth flagging

- **Case-sensitive literal extraction.** Trades discovery softness for behavior consistent with the single-doc `replace` op the agent will probably call next.
- **No cursor pagination.** Skill points callers at tighter `q` or higher `limit` (max 100) for narrower results; `/api/list?search=` remains the broad-listing surface.
- **No `kind`/`tags` filter params in v1.** Easy to add later; the ticket didn't require them.

## Skill

Adds a `## Search` section to `.claude/skills/md-niftymonkey/SKILL.md` documenting the two-stage contract and case sensitivity. Frontmatter description gains a `"which of my md docs mention X"` trigger. CI sync resyncs the hosted copy on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated search API endpoint enabling document search by query term, with match context previews (line numbers and text snippets).
  * Search results are scoped to the authenticated user's documents and include metadata (title, kind, tags) with accurate match counts.

* **Documentation**
  * Updated skill documentation with full search endpoint specification, usage examples, and behavior details.

* **Tests**
  * Added comprehensive test suite covering search functionality including query matching, result limits, authentication, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/md/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->