### PR TITLE
docs(architecture): reflect AI-First API as-shipped decisions

### DIFF
--- a/docs/architecture/ai-first-api.md
+++ b/docs/architecture/ai-first-api.md
@@ -1,6 +1,6 @@
 # AI-first API for md.niftymonkey.dev
 
-Architect-deep output, captured 2026-05-04. Ad-hoc design conversation, saved at the user's request so the next session can resume from this exact state. Not yet a PRD or plan — module shapes and phasing only.
+Architect-deep output, captured 2026-05-04 and revised 2026-05-22 once the work shipped. The original draft framed phasing as a recommendation; this revision records the API as it landed across PRs #47, #48, #54, #58, #59, #60, #61, #63, and #64. Items considered during the design and explicitly not built live under **Dismissed** below.
 
 ## Origin and intent
 
@@ -28,7 +28,7 @@ Five survive the deletion test for AI-first work specifically. One candidate (a 
 ### OperationApplier *(pure, in-process)*
 - **Interface:** `apply(content, ops[]) → {content, perOpResults} | {failedAt, error, partialResults}`
 - **What it hides:** ambiguity detection, line-shift bookkeeping, atomic rollback, the resolution rule (*line-addressed ops resolve against the batch-start snapshot; string-addressed ops resolve against running content*).
-- **Leverage:** every mutating verb — single edit, batch, dry-run, future section-replace — calls this one function.
+- **Leverage:** every mutating verb — single edit, batch, dry-run, section-replace — calls this one function.
 - **Locality:** all edit semantics, including the subtle ones, land in one file with one test file.
 
 ### MatchResolver *(pure, in-process)*
@@ -37,13 +37,13 @@ Five survive the deletion test for AI-first work specifically. One candidate (a 
 - **Leverage:** OperationApplier *and* the dry-run path both consume it. Two real callers — earns its seam.
 
 ### EditOpSchema *(types)*
-- Discriminated union: `replace`, `insertAfterLine`, `insertBeforeLine`, `deleteLineRange`, `replaceLineRange`. Phase-2 adds `replaceSection`.
+- Discriminated union: `replace`, `insertAfterLine`, `insertBeforeLine`, `deleteLineRange`, `replaceLineRange`, `setContent`, `replaceSection`.
 - **Why a module:** the same type is the request body, the applier input, and the test fixture. Defining it once anchors the contract.
 
-### SectionAddresser *(in-process, deferred to phase 2)*
+### SectionAddresser *(in-process, shipped in phase 2 via PR #60)*
 - **Interface:** `resolveSection(content, headingPath) → {fromLine, toLine}`.
 - **What it hides:** markdown AST work (heading levels, sibling boundaries, edge cases like duplicate headings).
-- **Leverage:** unlocks `replace_section`, the most natural edit unit for prose. Don't ship it in phase 1 — phase-1 string+line ops cover 80% and SectionAddresser earns more depth once real usage points at the gaps.
+- **Leverage:** unlocks `replaceSection`, the most natural edit unit for prose. Deliberately held out of phase 1 so phase-1 string and line ops could cover 80% of cases first; SectionAddresser then earned its depth against real usage.
 
 ### AgentEndpoints *(HTTP layer, namespaced at `/api/agent/*`)*
 - **Interface:** the verbs below. Every handler is a thin wrapper: parse → call applier → call `DocMutationPath.writeDocContent` (from #45) → return typed result or structured 409.
@@ -56,40 +56,53 @@ No category-3 or category-4 dependencies surfaced. **No external ports.** Tests 
 
 Two modules ship in #45 and are reused here. Full design lives in `docs/architecture/revision-history.md`.
 
-- **`DocMutationPath`** — the chokepoint every content write flows through. Signature: `writeDocContent({docId, newContent, summary, source, ownerId}) → {version}`. The agent edit handler calls it with `source: 'agent'`. Revision recording, diff stats, and transaction boundary are all inside.
+- **`DocMutationPath`**: the chokepoint every content write flows through. Signature as shipped: `writeDocContent({docId, newContent, summary, source, ownerId, expectedRevisionId?, newTitle?, newSearchText?, newKind?, newTags?})` returns `{ok: true, doc, revisionId}` on success or `{ok: false, kind: 'revision_mismatch', currentRevisionId}` when an `expectedRevisionId` was passed and did not match under `FOR UPDATE`. The agent edit handler calls it with `source: 'agent'`. Revision recording, diff stats, and the transaction boundary are all inside.
 - **`RevisionLog`** — owns `doc_revisions`. The agent surface doesn't call it directly; it goes through `DocMutationPath`.
 
 The `source` enum (defined in #45): `'manual' | 'cli' | 'agent' | 'restore'`. The `'agent'` value is reserved for this surface — added to the enum in #45 so #46 doesn't need a schema migration.
 
-## Phased path
+## Phased path (as shipped)
 
-> **Prerequisite:** issue #45 (Document revision history with restore). Ships the `doc_revisions` table, `RevisionLog` module, `DocMutationPath` chokepoint, `DiffStats` utility, history API verbs, and history UI before this work begins. The AI-first surface inherits all of it through a single `DocMutationPath.writeDocContent(..., source: 'agent')` call from the new edit handler.
+> **Prerequisite:** issue #45 (Document revision history with restore). Shipped the `doc_revisions` table, `RevisionLog` module, `DocMutationPath` chokepoint, `DiffStats` utility, history API verbs, and history UI. The AI-first surface inherits all of it through a single `DocMutationPath.writeDocContent(..., source: 'agent')` call from each edit handler.
 
-### Phase 1 — Minimum AI-first surface
-- `EditOpSchema` + `MatchResolver` + `OperationApplier` as in-process modules. Fully unit-tested with zero HTTP.
-- `POST /api/agent/docs/<slug>/edits` — body `{ops: [...]}`, atomic, structured errors with line previews. Handler runs `OperationApplier.apply(...)` to compute new content, then calls `DocMutationPath.writeDocContent({source: 'agent', summary, ...})` (module shipped in #45). Every agent edit flows through the same chokepoint as manual edits and is recorded automatically.
-- `GET /api/agent/docs/<slug>` — JSON `{content, version, updatedAt}`.
-- `POST /api/agent/docs` — create (mirror of `/api/upload`, JSON-shaped, lives in the agent namespace for surface symmetry).
-- Update `~/.claude/skills/md-upload/SKILL.md` to teach the edit verb. (Or split into a sibling `md-edit` skill — leans toward separate so each skill stays single-purpose and triggers cleanly.)
+Every phase below is merged. PR references identify the change that landed each item.
 
-### Phase 2 — Quality of life
-- `If-Match: <version>` enforcement on `/edits`.
-- `dryRun: true` on `/edits` — uses MatchResolver alone, no write.
-- `GET /api/agent/docs/<slug>/revisions` (list), `POST /api/agent/docs/<slug>/restore`.
-- `SectionAddresser` ships, unlocking `replaceSection` ops.
+### Phase 1: Minimum AI-first surface (PR #48, closes #46)
+- `EditOpSchema` + `MatchResolver` + `OperationApplier` as in-process modules, fully unit-tested with zero HTTP.
+- `POST /api/agent/docs/<slug>/edits`: body `{ops: [...]}`, per-batch atomic, structured 409 with line previews. The handler runs `OperationApplier.apply(...)` to compute new content, then calls `DocMutationPath.writeDocContent({source: 'agent', summary, ...})`. Every agent edit flows through the same chokepoint as manual edits and is recorded automatically.
+- `GET /api/agent/docs/<slug>`: JSON `{id, slug, title, kind, tags, content, lineCount, createdAt, updatedAt, revisionId}`.
+- `POST /api/agent/docs`: create, a JSON-shaped mirror of `/api/upload` in the agent namespace for surface symmetry.
 
-### Phase 3 — Multi-doc leverage
-- `POST /api/agent/edits` — cross-doc batch, per-doc atomic.
-- `GET /api/agent/search?q=...` — owner-scoped grep across all docs, returning slug + match contexts.
-- Skill consolidation if md-upload + md-edit both feel cramped.
+**Bonus DX added during Phase 1 (PR #54):**
+- `setContent` op for full-document saves; exclusive in its batch (mixing with other ops is rejected at parse time, since their resolution rules become ill-defined once the body is wiped).
+- `to: -1` sentinel on line ranges, meaning "to end of document". Resolution surfaces the resolved value before overlap detection so two `-1` ops compare correctly.
+- `lineCount` on the GET response, computed by the same `visibleLineCount` rule the applier uses internally, so the agent and the server cannot disagree.
+
+### Phase 2: Quality of life
+- `dryRun: true` on `/edits` (PR #58, closes #49). Runs `OperationApplier.apply` and `MatchResolver` as normal, skips the persist step, and returns the would-be result or the structured 409.
+- Optimistic concurrency via `current_revision_id` (PR #59, closes #51). Agents echo the GET response's `revisionId` in an `If-Match: <revisionId>` header; mismatch returns **412** with `currentRevisionId`. The check is re-run under `FOR UPDATE` inside `writeDocContent`, so a stale write that slipped past the cheap pre-check still 412s.
+- `replaceSection` op (PR #60, closes #50). New `SectionAddresser` module over the markdown AST resolves a `headingPath` to a line range; the existing applier consumes the result.
+- `md-niftymonkey` skill moved in-repo at `.claude/skills/md-niftymonkey/SKILL.md` with `.github/workflows/sync-skill.yml` mirroring it to the on-md hosted copy (PR #61, closes #56). One skill teaches the entire shipped surface; the hosted copy is a published artifact, not a fork.
+
+### Phase 3: Multi-document leverage
+- `POST /api/agent/edits`: cross-document batch (PR #63, closes #53). Per-document atomic via `OperationApplier` + `DocMutationPath`; batch best-effort with a per-doc `{slug, status, ...}` results array. Always returns 200; per-doc outcomes live in `results`. `If-Match` is single-doc only (a single header cannot address N docs); duplicate slugs are rejected at parse time.
+- `GET /api/agent/search?q=...`: owner-scoped full-text search returning per-match `{line, column, previewLines}` contexts (PR #64, closes #52). FTS narrows the candidate set, then `findMatches` extracts literal substring contexts; candidates that fail the literal check (case mismatch, stem-only) drop out, so every returned doc carries actionable matches. Per-doc match cap of 5 with the true total in `matchCount`.
 
 ## What this gets us
 
 - **Existing CLI/scripting consumers untouched.** `/api/*` keeps last-write-wins semantics; nothing breaks.
-- **Agents get a surface shaped like their tools.** `Edit`-style ops, structured ambiguity errors, version-aware reads. The skill is the handshake — when an agent sees `md-edit`'s SKILL.md in context, it inherits the calling pattern.
+- **Agents get a surface shaped like their tools.** `Edit`-style ops, structured ambiguity errors, revision-aware reads with optimistic concurrency. The skill is the handshake: when an agent sees `md-niftymonkey`'s SKILL.md in context, it inherits the calling pattern.
 - **Recoverability lands first**, so the moment the new mutation verb exists, every write is reversible — including writes through the old API.
-- **One engine, two surfaces.** OperationApplier serves `/api/agent/edits` today and could back a future `/api/edits` v2 if the CLI surface ever wants to converge.
+- **One engine, every surface.** OperationApplier serves both agent edit endpoints (single-doc `/api/agent/docs/<slug>/edits` and cross-doc `/api/agent/edits`) and could back a future `/api/edits` v2 if the CLI surface ever wants to converge.
 
-## Open thread
+## Dismissed
 
-User signaled they want to dig into "a different facet of this" next. Resume from the end of this doc — no decisions are locked yet, no PRD has been drafted, no issues have been filed. Phasing above is a recommendation, not a commitment.
+Considered during the design and explicitly not built. Recorded here so future sessions do not re-litigate.
+
+- **Agent-namespace revisions and restore mirrors.** The original Phase 2 listed `GET /api/agent/docs/<slug>/revisions` and `POST /api/agent/docs/<slug>/restore`. Dismissed: the existing `/api/docs/<slug>/revisions` and `/api/docs/<slug>/restore` already accept bearer auth (shipped in PR #47), so agents use those today. Duplicating the routes into `/api/agent/*` adds maintenance for no behavior gain.
+- **Two-skill split (`md-upload` + `md-edit`).** The original Phase 1 floated splitting the skill. As shipped, one `md-niftymonkey` skill teaches the whole API (upload, fetch, search, edit, list, delete) without trigger conflicts. The original Phase 3 "skill consolidation" item is dismissed for the same reason: there is nothing to consolidate.
+- **`version` integer column for optimistic concurrency.** The original Phase 1 GET listed `{content, version, updatedAt}` and Phase 2 referenced `If-Match: <version>`. As shipped (PR #59), concurrency uses `current_revision_id` instead. The GET response carries `revisionId`; the agent sends `If-Match: <revisionId>`; mismatch returns 412 with `currentRevisionId`. Reusing the existing revision external-id avoided introducing a parallel monotonic counter and matched the column already needed for fast current-revision lookups.
+
+## Status
+
+As of 2026-05-22 the AI-first API surface is complete. Phase 1, Phase 2, and Phase 3 are all merged; the `md-niftymonkey` skill teaches every shipped verb and is CI-synced from the repo to its hosted copy. The phased plan above is now a record of what shipped, not a roadmap. Future work on this surface should be filed as new tickets.


### PR DESCRIPTION
Closes #57.

The AI-First API architecture doc was written upfront as a recommendation. As Phase 1, 2, and 3 shipped, several decisions diverged from or refined the original phasing; this PR brings the doc in line with what merged so future sessions stop seeing stale guidance.

## What changed

- **Header now records the revision pass** and points readers at the new **Dismissed** section.
- **`EditOpSchema` bullet** lists the full shipped op set (`setContent` and `replaceSection` added; "Phase-2 adds" note removed).
- **`DocMutationPath` signature** corrected to the as-shipped result type, including `expectedRevisionId` input and the `revision_mismatch` branch.
- **`SectionAddresser` annotation** flipped from "deferred to phase 2" to "shipped in phase 2 via PR #60"; the bullet's tone moved from "don't ship in phase 1" to historical rationale.
- **Phased path rewritten as shipped.** Every bullet carries its PR and the issue it closed. Phase 1 (PR #48 + bonus DX in PR #54). Phase 2 (#58 dryRun / #59 If-Match / #60 replaceSection / #61 skill in-repo). Phase 3 (#63 cross-doc batch / #64 search).
- **"What this gets us"**: `version-aware reads` is now `revision-aware reads with optimistic concurrency`; the skill-handshake line points at `md-niftymonkey` instead of the never-built `md-edit`; the OperationApplier closing bullet names both edit endpoints.
- **"Open thread" replaced with two new sections**:
  - **Dismissed** records, with reasoning, the three considered-but-not-built items: agent-namespace revisions and restore mirrors (dismissed because `/api/docs/<slug>/revisions` and `/restore` already accept bearer auth), the two-skill `md-upload` + `md-edit` split, and the proposed `version` integer column for optimistic concurrency (concurrency uses `current_revision_id` instead).
  - **Status** marks the surface complete as of 2026-05-22 and notes the phased plan is now a record, not a roadmap.

## Why this matters

The original doc is referenced as the design source for ongoing work. Drift between the doc and `main` invites future tickets to re-litigate decisions that have already been made. With this rewrite, anyone landing on `docs/architecture/ai-first-api.md` sees the shipped state and the dismissed alternatives, not the upfront plan.

After this lands, the AI-First API ticket chain (#46, #49 through #57) is fully closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI-first API architecture documentation to reflect the shipped implementation, including supported operations, endpoint behaviors across phases, revision control semantics, optimistic concurrency handling, and batch edit limitations.
  * Clarified which features were shipped versus deferred in the phased rollout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/md/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->